### PR TITLE
Fix a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/sinokylin/terraform-provider-ovirt`
+Clone repository to: `$GOPATH/src/github.com/EMSL-MSC/terraform-provider-ovirt`
 
 ```sh
 $ mkdir -p $GOPATH/src/github.com/EMSL-MSC


### PR DESCRIPTION
Uses should clone the repo into `$GOPATH/src/github.com/EMSL-MSC/terraform-provider-ovirt`, instead of the incorrect `$GOPATH/src/github.com/sinokylin/terraform-provider-ovirt` as described in README.