### PR TITLE
Update the dependecy of oVirt Go SDK to v4.3.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.12
 
 require (
 	github.com/hashicorp/terraform v0.12.2
-	github.com/ovirt/go-ovirt v4.3.4+incompatible
+	github.com/ovirt/go-ovirt v4.3.5+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -281,8 +281,8 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
-github.com/ovirt/go-ovirt v4.3.4+incompatible h1:jXcJpcXyNZ3mXJ1IVU3l3tMpE4JEUSNjqRiEJnVpG40=
-github.com/ovirt/go-ovirt v4.3.4+incompatible/go.mod h1:r33ZGjVKCPMiI6hw791/Zx8tNKk0Gn+4VFWbOfyIvZQ=
+github.com/ovirt/go-ovirt v4.3.5+incompatible h1:8ZVJAbZfSDLHHk6wYvlmUl9MrcIkv3jYLhTRf1NxAYQ=
+github.com/ovirt/go-ovirt v4.3.5+incompatible/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
 github.com/packer-community/winrmcp v0.0.0-20180102160824-81144009af58 h1:m3CEgv3ah1Rhy82L+c0QG/U3VyY1UsvsIdkh0/rU97Y=
 github.com/packer-community/winrmcp v0.0.0-20180102160824-81144009af58/go.mod h1:f6Izs6JvFTdnRbziASagjZ2vmf55NSIkC/weStxCHqk=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/vendor/github.com/ovirt/go-ovirt/CHANGES.adoc
+++ b/vendor/github.com/ovirt/go-ovirt/CHANGES.adoc
@@ -1,0 +1,108 @@
+= Changes
+
+This document describes the relevant changes between releases of the SDK.
+
+== 4.3.5 / Jun 25 2019
+
+Update to model 4.4.2.
+
+  New features:
+
+* Allow setting a disk ScsiGenericIO to disabled
+  https://bugzilla.redhat.com/1714834[1714834].
+
+* Treat image transfers cancelled by user/system differently
+  https://bugzilla.redhat.com/1533362[1533362].
+
+Leverage `go module` for dependency management.
+
+
+== 4.3.4 / May 23 2019
+Add v before tag names.
+
+
+== 4.3.3 / May 16 2019
+Update to model 4.4.0.
+
+  New features:
+
+ * Add new parameters to HostsService.List and VmService.Migrate
+  https://bugzilla.redhat.com/1651406[1651406].
+
+
+== 4.3.2 / Apr 10 2019
+Update to model 4.3.22.
+
+  New features:
+
+ * Add Upgrade action to cluster to set upgrade_action flag of cluster via API
+  Bug-Url: https://bugzilla.redhat.com/1663626[1663626].
+
+ * Add Hosted Engine disk types to content type
+  Bug-Url: https://bugzilla.redhat.com/1600788[1600788].
+
+Bug fixes:
+
+* Fix sdk compiling errors when updating to model 4.3.22
+ Bug-Url: https://github.com/oVirt/ovirt-engine-sdk-go/issues/151[#151]
+
+
+== 4.3.1 / Apr 8 2019
+Update to model 4.3.21.
+
+ New features:
+
+ * Add `activate` input param to add/install/approve host
+  http://bugzilla.redhat.com/1561539[1561539].
+
+ * Added support for incremental backup.
+
+ * Added block size Storage domain property
+  https://bugzilla.redhat.com/1592916[1592916].
+
+ * Added V5 storage format
+  https://bugzilla.redhat.com/1592916[1592916].
+
+ * Add driverSensitiveOptions to managed block storage type.
+
+ * Add managed block storage type.
+
+ * Setup networks commit on success.
+
+ * Add vGPU placement to Host
+  https://bugzilla.redhat.com/1641125[1641125].
+
+ * Specify cloud-init protocol in vm intialization
+  https://bugzilla.redhat.com/1611889[1611889].
+
+ * Added SATA to DiskInterface enum.
+
+ * Add disks link to Snapshot type.
+
+ Bug fixes:
+
+ * Change HostNic statistics and labels to Link
+  https://bugzilla.redhat.com/1661207[1661207].
+
+
+== 4.3.0 / Mar 14 2019
+
+This is the first stable release after being migrated to oVirt organization.
+
+The notable changes includes:
+
+* Update metamodel to 4.3.20
+
+* Change import path to `github.com/ovirt/go-ovirt`
+
+* Use https://developer.github.com/v3/guides/managing-deploy-keys/[Github deploy keys] as the credentials to deploy the auto-generated codes
+
+== 4.2.2 / Jan 24 2019
+
+Add support for semantic versioning, which is also considered to be the 
+recommended way for dependencies management.
+
+== 4.2.1 / Jan 16 2019
+
+This is considered to be the first stable release version in 4.2.x.
+In this release the model version is 4.2.37 and metamodel is 1.2.16.

--- a/vendor/github.com/ovirt/go-ovirt/LICENSE.txt
+++ b/vendor/github.com/ovirt/go-ovirt/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/vendor/github.com/ovirt/go-ovirt/go.mod
+++ b/vendor/github.com/ovirt/go-ovirt/go.mod
@@ -1,0 +1,5 @@
+module github.com/ovirt/go-ovirt
+
+go 1.12
+
+require github.com/stretchr/testify v1.3.0

--- a/vendor/github.com/ovirt/go-ovirt/go.sum
+++ b/vendor/github.com/ovirt/go-ovirt/go.sum
@@ -1,0 +1,7 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/vendor/github.com/ovirt/go-ovirt/types.go
+++ b/vendor/github.com/ovirt/go-ovirt/types.go
@@ -86665,8 +86665,12 @@ type ImageTransferPhase string
 
 const (
 	IMAGETRANSFERPHASE_CANCELLED          ImageTransferPhase = "cancelled"
+	IMAGETRANSFERPHASE_CANCELLED_SYSTEM   ImageTransferPhase = "cancelled_system"
+	IMAGETRANSFERPHASE_CANCELLED_USER     ImageTransferPhase = "cancelled_user"
+	IMAGETRANSFERPHASE_FINALIZING_CLEANUP ImageTransferPhase = "finalizing_cleanup"
 	IMAGETRANSFERPHASE_FINALIZING_FAILURE ImageTransferPhase = "finalizing_failure"
 	IMAGETRANSFERPHASE_FINALIZING_SUCCESS ImageTransferPhase = "finalizing_success"
+	IMAGETRANSFERPHASE_FINISHED_CLEANUP   ImageTransferPhase = "finished_cleanup"
 	IMAGETRANSFERPHASE_FINISHED_FAILURE   ImageTransferPhase = "finished_failure"
 	IMAGETRANSFERPHASE_FINISHED_SUCCESS   ImageTransferPhase = "finished_success"
 	IMAGETRANSFERPHASE_INITIALIZING       ImageTransferPhase = "initializing"
@@ -86970,6 +86974,7 @@ const (
 type ScsiGenericIO string
 
 const (
+	SCSIGENERICIO_DISABLED   ScsiGenericIO = "disabled"
 	SCSIGENERICIO_FILTERED   ScsiGenericIO = "filtered"
 	SCSIGENERICIO_UNFILTERED ScsiGenericIO = "unfiltered"
 )

--- a/vendor/github.com/ovirt/go-ovirt/version.go
+++ b/vendor/github.com/ovirt/go-ovirt/version.go
@@ -16,4 +16,4 @@
 package ovirtsdk
 
 // The version of the SDK:
-var SDK_VERSION = "4.3.4"
+var SDK_VERSION = "4.3.5"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -200,7 +200,7 @@ github.com/mitchellh/mapstructure
 github.com/mitchellh/reflectwalk
 # github.com/oklog/run v1.0.0
 github.com/oklog/run
-# github.com/ovirt/go-ovirt v4.3.4+incompatible
+# github.com/ovirt/go-ovirt v4.3.5+incompatible
 github.com/ovirt/go-ovirt
 # github.com/posener/complete v1.2.1
 github.com/posener/complete


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>


Changes proposed in this pull request:

* Update oVirt Go SDK to the latest `v4.3.5`, along with relevant vendor files

