### PR TITLE
Uninstall renovate-bot integration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ],
-  "postUpdateOptions": [
-    "gomodTidy"
-  ]
-}


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

In accordance to the discussions in #151 , we decide to remove the integration with renovate-bot which deal with the update of deps automatically. We believe a fine-grained control on updating deps will always keep the project stable, simple and production-ready.

Changes proposed in this pull request:

* Remove the configuration files of renovate-bot

