### PR TITLE
Set Go flags and remove the legacy govendor package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ install:
 # packages that live there.
 # See: https://github.com/golang/go/issues/12933
 - bash scripts/gogetcookie.sh
-- go get github.com/kardianos/govendor
 
 script:
 - make test
@@ -26,3 +25,5 @@ matrix:
   fast_finish: true
   allow_failures:
   - go: tip
+env:
+  - GOFLAGS=-mod=vendor GO111MODULE=on

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -41,9 +41,6 @@ fmtcheck:
 errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
 
-vendor-status:
-	@govendor status
-
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \
 		echo "ERROR: Set TEST to a specific package. For example,"; \
@@ -67,5 +64,5 @@ endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test
+.PHONY: build test testacc vet fmt fmtcheck errcheck test-compile website website-test
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Add extra flags for go command to enable go modules and force to use go code in `vendor`.
* Eliminate the legacy `govendor` package


Signed-off-by: imjoey <majunjiev@gmail.com>