### PR TITLE
Format the HCL code snippets defined in acceptance tests

### DIFF
--- a/ovirt/data_source_ovirt_authzs_test.go
+++ b/ovirt/data_source_ovirt_authzs_test.go
@@ -32,9 +32,9 @@ func TestAccOvirtAuthzsDataSource_nameRegexFilter(t *testing.T) {
 
 var testAccCheckOvirtAuthzsDataSourceNameRegexConfig = `
 data "ovirt_authzs" "name_regex_filtered_authz" {
-	name_regex = "^internal-*"
-	search {
-		max = 1
-	}
+  name_regex = "^internal-*"
+  search {
+    max = 1
+  }
 }
 `

--- a/ovirt/data_source_ovirt_clusters_test.go
+++ b/ovirt/data_source_ovirt_clusters_test.go
@@ -51,16 +51,16 @@ func TestAccOvirtClustersDataSource_searchFilter(t *testing.T) {
 
 var testAccCheckOvirtClustersDataSourceNameRegexConfig = `
 data "ovirt_clusters" "name_regex_filtered_cluster" {
-	name_regex = "^Default*"
-  }
+  name_regex = "^Default*"
+}
 `
 
 var testAccCheckOvirtClustersDataSourceSearchConfig = `
 data "ovirt_clusters" "search_filtered_cluster" {
-	search = {
-	  criteria       = "name = Default"
-	  max            = 1
-	  case_sensitive = false
-	}
+  search = {
+    criteria       = "name = Default"
+    max            = 1
+    case_sensitive = false
+  }
 }
 `

--- a/ovirt/data_source_ovirt_datacenters_test.go
+++ b/ovirt/data_source_ovirt_datacenters_test.go
@@ -48,16 +48,16 @@ func TestAccOvirtDataCentersDataSource_searchFilter(t *testing.T) {
 
 var testAccCheckOvirtDataCentersDataSourceNameRegexConfig = `
 data "ovirt_datacenters" "name_regex_filtered_datacenter" {
-	name_regex = "^Defa*"
-  }
+  name_regex = "^Defa*"
+}
 `
 
 var testAccCheckOvirtDataCentersDataSourceSearchConfig = `
 data "ovirt_datacenters" "search_filtered_datacenter" {
-	search = {
-	  criteria       = "name = Default and status = up and Storage.name = data"
-	  max            = 2
-	  case_sensitive = false
-	}
+  search = {
+    criteria       = "name = Default and status = up and Storage.name = data"
+    max            = 2
+    case_sensitive = false
   }
+}
 `

--- a/ovirt/data_source_ovirt_disks_test.go
+++ b/ovirt/data_source_ovirt_disks_test.go
@@ -53,16 +53,16 @@ func TestAccOvirtDisksDataSource_searchFilter(t *testing.T) {
 
 var testAccCheckOvirtDisksDataSourceNameRegexConfig = `
 data "ovirt_disks" "name_regex_filtered_disk" {
-	name_regex = "^test_disk*"
-  }
+  name_regex = "^test_disk*"
+}
 `
 
 var testAccCheckOvirtDisksDataSourceSearchConfig = `
 data "ovirt_disks" "search_filtered_disk" {
-	search = {
-	  criteria       = "name = test_disk1 and provisioned_size > 1024000000"
-	  max            = 1
-	  case_sensitive = false
-	}
+  search = {
+    criteria       = "name = test_disk1 and provisioned_size > 1024000000"
+    max            = 1
+    case_sensitive = false
   }
+}
 `

--- a/ovirt/data_source_ovirt_hosts_test.go
+++ b/ovirt/data_source_ovirt_hosts_test.go
@@ -51,16 +51,16 @@ func TestAccOvirtHostsDataSource_searchFilter(t *testing.T) {
 
 var testAccCheckOvirtHostsDataSourceNameRegexConfig = `
 data "ovirt_hosts" "name_regex_filtered_host" {
-	name_regex = "^host*"
-  }
+  name_regex = "^host*"
+}
 `
 
 var testAccCheckOvirtHostsDataSourceSearchConfig = `
 data "ovirt_hosts" "search_filtered_host" {
-	search = {
-	  criteria       = "name = host65"
-	  max            = 1
-	  case_sensitive = false
-	}
+  search = {
+    criteria       = "name = host65"
+    max            = 1
+    case_sensitive = false
+  }
 }
 `

--- a/ovirt/data_source_ovirt_mac_pools_test.go
+++ b/ovirt/data_source_ovirt_mac_pools_test.go
@@ -32,9 +32,9 @@ func TestAccOvirtMacPoolsDataSource_nameRegexFilter(t *testing.T) {
 
 var testAccCheckOvirtMacPoolsDataSourceNameRegexConfig = `
 data "ovirt_mac_pools" "name_regex_filtered_pool" {
-	name_regex = "\\w*efault*"
-	search {
-		max = 1
-	}
+  name_regex = "\\w*efault*"
+  search {
+    max = 1
+  }
 }
 `

--- a/ovirt/data_source_ovirt_networks_test.go
+++ b/ovirt/data_source_ovirt_networks_test.go
@@ -49,16 +49,16 @@ func TestAccOvirtNetworksDataSource_searchFilter(t *testing.T) {
 
 var testAccCheckOvirtNetworksDataSourceNameRegexConfig = `
 data "ovirt_networks" "name_regex_filtered_network" {
-	name_regex = "^ovirtmgmt-t*"
-  }
+  name_regex = "^ovirtmgmt-t*"
+}
 `
 
 var testAccCheckOvirtNetworksDataSourceSearchConfig = `
 data "ovirt_networks" "search_filtered_network" {
-	search = {
-	  criteria       = "datacenter = Default and name = ovirtmgmt-test"
-	  max            = 1
-	  case_sensitive = false
-	}
+  search = {
+    criteria       = "datacenter = Default and name = ovirtmgmt-test"
+    max            = 1
+    case_sensitive = false
+  }
 }
 `

--- a/ovirt/data_source_ovirt_storagedomains_test.go
+++ b/ovirt/data_source_ovirt_storagedomains_test.go
@@ -53,16 +53,16 @@ func TestAccOvirtStorageDomainsDataSource_searchFilter(t *testing.T) {
 
 var TestAccOvirtStorageDomainsDataSourceNameRegexConfig = `
 data "ovirt_storagedomains" "name_regex_filtered_storagedomain" {
-	name_regex = "^MAIN_dat.*|^DEV_dat.*"
-  }
+  name_regex = "^MAIN_dat.*|^DEV_dat.*"
+}
 `
 
 var TestAccOvirtStorageDomainsDataSourceSearchConfig = `
 data "ovirt_storagedomains" "search_filtered_storagedomain" {
-	name_regex = "^DS_*"
-	search = {
-	  criteria       = "status != unattached and name = DS_INTERNAL and datacenter = MY_DC"
-	  case_sensitive = false
-	}
+  name_regex = "^DS_*"
+  search = {
+    criteria       = "status != unattached and name = DS_INTERNAL and datacenter = MY_DC"
+    case_sensitive = false
   }
+}
 `

--- a/ovirt/data_source_ovirt_users_test.go
+++ b/ovirt/data_source_ovirt_users_test.go
@@ -49,15 +49,15 @@ func TestAccOvirtUsersDataSource_searchFilter(t *testing.T) {
 
 var testAccCheckOvirtUsersDataSourceNameRegexConfig = `
 data "ovirt_users" "name_regex_filtered_user" {
-	name_regex = "^admin*"
+  name_regex = "^admin*"
 }
 `
 
 var testAccCheckOvirtUsersDataSourceSearchConfig = `
 data "ovirt_users" "search_filtered_user" {
-	search {
-		max      = 1
-		criteria = "name = admin"
-	}
+  search {
+    max      = 1
+    criteria = "name = admin"
+  }
 }
 `

--- a/ovirt/data_source_ovirt_vms_test.go
+++ b/ovirt/data_source_ovirt_vms_test.go
@@ -48,16 +48,16 @@ func TestAccOvirtVMsDataSource_searchFilter(t *testing.T) {
 
 var testAccCheckOvirtVMsDataSourceNameRegexConfig = `
 data "ovirt_vms" "name_regex_filtered_vm" {
-	name_regex = "\\w*ostedEn*"
+  name_regex = "\\w*ostedEn*"
 }
 `
 
 var testAccCheckOvirtVMsDataSourceSearchConfig = `
 data "ovirt_vms" "search_filtered_vm" {
-	search = {
-	  criteria       = "name = HostedEngine and status = up"
-	  max            = 2
-	  case_sensitive = false
-	}
+  search = {
+    criteria       = "name = HostedEngine and status = up"
+    max            = 2
+    case_sensitive = false
+  }
 }
 `

--- a/ovirt/data_source_ovirt_vnic_profiles_test.go
+++ b/ovirt/data_source_ovirt_vnic_profiles_test.go
@@ -27,7 +27,7 @@ func TestAccOvirtVNicProfilesDataSource_nameRegexFilter(t *testing.T) {
 
 var testAccCheckOvirtVNicProfilesDataSourceNameRegexConfig = `
 data "ovirt_vnic_profiles" "name_regex_filtered_cluster" {
-	name_regex = ".*mirror$"
-	network_id = "649f2d61-7f23-477b-93bd-d55f974d8bc8"
-  }
+  name_regex = ".*mirror$"
+  network_id = "649f2d61-7f23-477b-93bd-d55f974d8bc8"
+}
 `

--- a/ovirt/resource_ovirt_cluster_test.go
+++ b/ovirt/resource_ovirt_cluster_test.go
@@ -101,32 +101,34 @@ func testAccCheckOvirtClusterExists(n string, v *ovirtsdk4.Cluster) resource.Tes
 func testAccClusterBasic(datacenterID, networkID string) string {
 	return fmt.Sprintf(`
 resource "ovirt_cluster" "cluster" {
-	name	    						= "testAccOvirtClusterBasic"
-	description 						= "Desc of cluster"
-	datacenter_id						= "%s"
-	management_network_id				= "%s"
-	memory_policy_over_commit_percent   = 100
-	ballooning							= true
-	gluster								= true
-	threads_as_cores					= true
-	cpu_arch							= "x86_64"
-	cpu_type							= "Intel SandyBridge Family"
-	compatibility_version				= "4.1"
-}`, datacenterID, networkID)
+  name                              = "testAccOvirtClusterBasic"
+  description                       = "Desc of cluster"
+  datacenter_id                     = "%s"
+  management_network_id             = "%s"
+  memory_policy_over_commit_percent = 100
+  ballooning                        = true
+  gluster                           = true
+  threads_as_cores                  = true
+  cpu_arch                          = "x86_64"
+  cpu_type                          = "Intel SandyBridge Family"
+  compatibility_version             = "4.1"
+}
+`, datacenterID, networkID)
 }
 
 func testAccClusterBasicUpdate(datacenterID, networkID string) string {
 	return fmt.Sprintf(`
 resource "ovirt_cluster" "cluster" {
-	name	    						= "testAccOvirtClusterBasicUpdate"
-	datacenter_id						= "%s"
-	management_network_id				= "%s"
-	memory_policy_over_commit_percent   = 100
-	ballooning							= true
-	gluster								= true
-	threads_as_cores					= true
-	cpu_arch							= "x86_64"
-	cpu_type							= "Intel SandyBridge Family"
-	compatibility_version				= "4.1"
-}`, datacenterID, networkID)
+  name                              = "testAccOvirtClusterBasicUpdate"
+  datacenter_id                     = "%s"
+  management_network_id             = "%s"
+  memory_policy_over_commit_percent = 100
+  ballooning                        = true
+  gluster                           = true
+  threads_as_cores                  = true
+  cpu_arch                          = "x86_64"
+  cpu_type                          = "Intel SandyBridge Family"
+  compatibility_version             = "4.1"
+}
+`, datacenterID, networkID)
 }

--- a/ovirt/resource_ovirt_datacenter_test.go
+++ b/ovirt/resource_ovirt_datacenter_test.go
@@ -94,16 +94,16 @@ func testAccCheckOvirtDataCenterExists(n string, v *ovirtsdk4.DataCenter) resour
 
 const testAccDataCenterBasic = `
 resource "ovirt_datacenter" "datacenter" {
-	name        = "testAccOvirtDataCenterBasic"
-	description = "my new dc"
-	local       = false
+  name        = "testAccOvirtDataCenterBasic"
+  description = "my new dc"
+  local       = false
 }
 `
 
 const testAccDataCenterBasicUpdate = `
 resource "ovirt_datacenter" "datacenter" {
-	name        = "testAccOvirtDataCenterBasicUpdate"
-	description = "my updated new dc"
-	local       = true
+  name        = "testAccOvirtDataCenterBasicUpdate"
+  description = "my updated new dc"
+  local       = true
 }
 `

--- a/ovirt/resource_ovirt_disk_attachment_test.go
+++ b/ovirt/resource_ovirt_disk_attachment_test.go
@@ -102,12 +102,12 @@ func testAccCheckOvirtDiskAttachmentExists(n string, diskAttachment *ovirtsdk4.D
 func testAccDiskAttachmentBasic(vmID, diskID string) string {
 	return fmt.Sprintf(`
 resource "ovirt_disk_attachment" "attachment" {
-	vm_id     = "%s"
-	disk_id   = "%s"
-	bootable  = true
-	interface = "virtio"
-	active    = true
-	read_only = true
+  vm_id     = "%s"
+  disk_id   = "%s"
+  bootable  = true
+  interface = "virtio"
+  active    = true
+  read_only = true
 }  
 `, vmID, diskID)
 }
@@ -115,12 +115,12 @@ resource "ovirt_disk_attachment" "attachment" {
 func testAccDiskAttachmentBasicUpdate(vmID, diskID string) string {
 	return fmt.Sprintf(`
 resource "ovirt_disk_attachment" "attachment" {
-	vm_id     = "%s"
-	disk_id   = "%s"
-	bootable  = false
-	interface = "virtio"
-	active    = false
-	read_only = true
+  vm_id     = "%s"
+  disk_id   = "%s"
+  bootable  = false
+  interface = "virtio"
+  active    = false
+  read_only = true
 }  
 `, vmID, diskID)
 }

--- a/ovirt/resource_ovirt_disk_test.go
+++ b/ovirt/resource_ovirt_disk_test.go
@@ -103,49 +103,49 @@ func testAccDiskBasic(clusterID, quotaID, storageDomainID string) string {
 	return fmt.Sprintf(`
 
 resource "ovirt_vm" "vm" {
-	name        = "testAccVM"
-	cluster_id  = "%s"
-	memory 	    = 1024 
+  name        = "testAccVM"
+  cluster_id  = "%s"
+  memory 	  = 1024 
 
-	block_device {
-		disk_id = "${ovirt_disk.disk.id}"
-		interface = "virtio"
-	}
+  block_device {
+    disk_id   = "${ovirt_disk.disk.id}"
+    interface = "virtio"
+  }
 }
 
 resource "ovirt_disk" "disk" {
-	name        	  = "testAccDiskBasic"
-	alias             = "testAccDiskBasic"
-	size              = 2
-	format            = "cow"
-	quota_id          = "%s"
-	storage_domain_id = "%s"
-	sparse            = true
+  name        	    = "testAccDiskBasic"
+  alias             = "testAccDiskBasic"
+  size              = 2
+  format            = "cow"
+  quota_id          = "%s"
+  storage_domain_id = "%s"
+  sparse            = true
 }
-	`, clusterID, quotaID, storageDomainID)
+`, clusterID, quotaID, storageDomainID)
 }
 
 func testAccDiskBasicUpdate(clusterID, quotaID, storageDomainID string) string {
 	return fmt.Sprintf(`
 resource "ovirt_vm" "vm" {
-	name        = "testAccVM"
-	cluster_id  = "%s"
-	memory 	    = 1024
+  name       = "testAccVM"
+  cluster_id = "%s"
+  memory     = 1024
 
-	block_device {
-		disk_id = "${ovirt_disk.disk.id}"
-		interface = "virtio"
-	}
+  block_device {
+    disk_id   = "${ovirt_disk.disk.id}"
+    interface = "virtio"
+  }
 }
 
 resource "ovirt_disk" "disk" {
-	name        	  = "testAccDiskBasicUpdate"
-	alias             = "testAccDiskBasicUpdate"
-	size              = 3
-	format            = "cow"
-	quota_id          = "%s"
-	storage_domain_id = "%s"
-	sparse            = true
+  name        	    = "testAccDiskBasicUpdate"
+  alias             = "testAccDiskBasicUpdate"
+  size              = 3
+  format            = "cow"
+  quota_id          = "%s"
+  storage_domain_id = "%s"
+  sparse            = true
 }
-	`, clusterID, quotaID, storageDomainID)
+`, clusterID, quotaID, storageDomainID)
 }

--- a/ovirt/resource_ovirt_host_test.go
+++ b/ovirt/resource_ovirt_host_test.go
@@ -99,21 +99,23 @@ func testAccCheckOvirtHostExists(n string, v *ovirtsdk4.Host) resource.TestCheck
 func testAccHostBasic(address, clusterID string) string {
 	return fmt.Sprintf(`
 resource "ovirt_host" "host" {
-	name        = "jnode1"
-	description = "my new host"
-	address		= "%s"
-	root_password = "secret"
-	cluster_id  = "%s"
-}`, address, clusterID)
+  name          = "jnode1"
+  description   = "my new host"
+  address       = "%s"
+  root_password = "secret"
+  cluster_id    = "%s"
+}
+`, address, clusterID)
 }
 
 func testAccHostBasicUpdate(address, clusterID string) string {
 	return fmt.Sprintf(`
 resource "ovirt_host" "host" {
-	name        = "jnode1"
-	description = "my updated new host"
-	address		= "%s"
-	root_password = "secret"
-	cluster_id  = "%s"
-}`, address, clusterID)
+  name          = "jnode1"
+  description   = "my updated new host"
+  address       = "%s"
+  root_password = "secret"
+  cluster_id    = "%s"
+}
+`, address, clusterID)
 }

--- a/ovirt/resource_ovirt_mac_pool_test.go
+++ b/ovirt/resource_ovirt_mac_pool_test.go
@@ -95,28 +95,30 @@ func testAccCheckOvirtMacPoolExists(n string, v *ovirtsdk4.MacPool) resource.Tes
 func testAccMacPoolBasic() string {
 	return fmt.Sprintf(`
 resource "ovirt_mac_pool" "pool" {
-	name 				= "testAccOvirtMacPoolBasic"
-	description			= "Desc of mac pool"
-	allow_duplicates	= true
+  name             = "testAccOvirtMacPoolBasic"
+  description      = "Desc of mac pool"
+  allow_duplicates = true
 	
-	ranges = [
-		"00:1a:4a:16:01:51,00:1a:4a:16:01:61",
-		"00:1a:4a:16:01:71,00:1a:4a:16:01:81",
-	]
-}`)
+  ranges = [
+    "00:1a:4a:16:01:51,00:1a:4a:16:01:61",
+    "00:1a:4a:16:01:71,00:1a:4a:16:01:81",
+  ]
+}
+`)
 }
 
 func testAccMacPoolBasicUpdate() string {
 	return fmt.Sprintf(`
 resource "ovirt_mac_pool" "pool" {
-	name 				= "testAccOvirtMacPoolBasicUpdate"
-	description			= "Desc of mac pool"
-	allow_duplicates	= true
+  name             = "testAccOvirtMacPoolBasicUpdate"
+  description      = "Desc of mac pool"
+  allow_duplicates = true
 	
-	ranges = [
-		"00:1a:4a:16:01:51,00:1a:4a:16:01:61",
-		"00:1a:4a:16:01:91,00:1a:4a:16:01:a1",
-		"00:1a:4a:16:01:b1,00:1a:4a:16:01:c1",
-	]
-}`)
+  ranges = [
+    "00:1a:4a:16:01:51,00:1a:4a:16:01:61",
+    "00:1a:4a:16:01:91,00:1a:4a:16:01:a1",
+    "00:1a:4a:16:01:b1,00:1a:4a:16:01:c1",
+  ]
+}
+`)
 }

--- a/ovirt/resource_ovirt_network_test.go
+++ b/ovirt/resource_ovirt_network_test.go
@@ -108,11 +108,11 @@ func testAccCheckOvirtNetworkExists(n string, v *ovirtsdk4.Network) resource.Tes
 func testAccNetworkBasic(datacenterID, desc string, vlanID, mtu int) string {
 	return fmt.Sprintf(`
 resource "ovirt_network" "network" {
-	name        	= "testAccOvirtNetworkBasic"
-	datacenter_id	= "%s"
-	description     = "%s"
-	vlan_id			= %d
-	mtu				= %d
+  name          = "testAccOvirtNetworkBasic"
+  datacenter_id = "%s"
+  description   = "%s"
+  vlan_id       = %d
+  mtu           = %d
 }
 `, datacenterID, desc, vlanID, mtu)
 }

--- a/ovirt/resource_ovirt_snapshot_test.go
+++ b/ovirt/resource_ovirt_snapshot_test.go
@@ -107,8 +107,8 @@ func testAccSnapshotBasic(description, vmID string, saveMemory bool) string {
 	return fmt.Sprintf(`
 resource "ovirt_snapshot" "snapshot" {
   description = "%s"
-  vm_id  = "%s"
+  vm_id       = "%s"
   save_memory = %t
 }
-	`, description, vmID, saveMemory)
+`, description, vmID, saveMemory)
 }

--- a/ovirt/resource_ovirt_storage_domain_test.go
+++ b/ovirt/resource_ovirt_storage_domain_test.go
@@ -92,16 +92,17 @@ func testAccCheckStorageDomainExists(n string, v *ovirtsdk4.StorageDomain) resou
 func testAccStorageDomainNFS(hostID, dcID, nfsAddr, nfsPath string) string {
 	return fmt.Sprintf(`
 resource "ovirt_storage_domain" "dataNFS" {
-	name                = "testAccOvirtStorageDomainNFS"
-	host_id             = "%s"
-	type                = "data"
-	datacenter_id       = "%s"
-	description         = "nfs storage domain descriptions"
-	wipe_after_delete   = "true"
+  name              = "testAccOvirtStorageDomainNFS"
+  host_id           = "%s"
+  type              = "data"
+  datacenter_id     = "%s"
+  description       = "nfs storage domain descriptions"
+  wipe_after_delete = "true"
 
-	nfs {
-		address = "%s"
-		path    = "%s"
-	}
-}`, hostID, dcID, nfsAddr, nfsPath)
+  nfs {
+    address = "%s"
+    path    = "%s"
+  }
+}
+`, hostID, dcID, nfsAddr, nfsPath)
 }

--- a/ovirt/resource_ovirt_tag_test.go
+++ b/ovirt/resource_ovirt_tag_test.go
@@ -142,36 +142,35 @@ func testAccCheckOvirtTagAttachedEntities(v *ovirtsdk4.Tag, field string, expect
 
 const testAccTagBasic = `
 resource "ovirt_tag" "tag" {
-	name        = "testAccOvirtTagBasic"
-	parent_id   = "00000000-0000-0000-0000-000000000000"
-	description = "my new tag"
+  name        = "testAccOvirtTagBasic"
+  parent_id   = "00000000-0000-0000-0000-000000000000"
+  description = "my new tag"
 	
-	vm_ids = [
-		"9c993532-9f70-4c56-88a2-b40d6b48283a",
-		"900bc22d-c776-4c87-93a6-41bb36eb4d8b",
-		"dcb76ed3-f7e6-4c53-a0be-87bde821e431",
-	]
+  vm_ids = [
+    "9c993532-9f70-4c56-88a2-b40d6b48283a",
+    "900bc22d-c776-4c87-93a6-41bb36eb4d8b",
+    "dcb76ed3-f7e6-4c53-a0be-87bde821e431",
+  ]
 
-	host_ids = [
-		"fa0e3d1b-f3a7-49d7-8e72-045e562f81a6",
-	]
+  host_ids = [
+    "fa0e3d1b-f3a7-49d7-8e72-045e562f81a6",
+  ]
 }
 `
 
 const testAccTagBasicUpdate = `
 resource "ovirt_tag" "tag" {
-	name        = "testAccOvirtTagBasicUpdate"
-	parent_id   = "00000000-0000-0000-0000-000000000000"
-	description = "my updated new tag"
+  name        = "testAccOvirtTagBasicUpdate"
+  parent_id   = "00000000-0000-0000-0000-000000000000"
+  description = "my updated new tag"
 
-	vm_ids = [
-		"9c993532-9f70-4c56-88a2-b40d6b48283a",
-		"423ebce9-30e8-8894-8216-a6f0ab803c4c",
-	]
+  vm_ids = [
+    "9c993532-9f70-4c56-88a2-b40d6b48283a",
+    "423ebce9-30e8-8894-8216-a6f0ab803c4c",
+  ]
 
-	host_ids = [
-		"269d7afe-6e70-4712-b179-0cd8821d7d30",
-	]
-	
+  host_ids = [
+    "269d7afe-6e70-4712-b179-0cd8821d7d30",
+  ]
 }
 `

--- a/ovirt/resource_ovirt_user_test.go
+++ b/ovirt/resource_ovirt_user_test.go
@@ -90,8 +90,9 @@ func testAccCheckOvirtUserExists(n string, v *ovirtsdk4.User) resource.TestCheck
 func testAccUserBasic() string {
 	return fmt.Sprintf(`
 resource "ovirt_user" "user" {
-	name         = "testAccOvirtUserBasic@internal"
-	namespace    = "*"
-	authz_name   = "example.com-authz"
-}`)
+  name       = "testAccOvirtUserBasic@internal"
+  namespace  = "*"
+  authz_name = "example.com-authz"
+}
+`)
 }

--- a/ovirt/resource_ovirt_vm_test.go
+++ b/ovirt/resource_ovirt_vm_test.go
@@ -271,111 +271,111 @@ func testAccCheckOvirtVMExists(n string, v *ovirtsdk4.Vm) resource.TestCheckFunc
 func testAccVMBasic(clusterID, templateID string) string {
 	return fmt.Sprintf(`
 resource "ovirt_vm" "vm" {
-	name        = "testAccVMBasic"
-	cluster_id  = "%s"
-	template_id = "%s"
-	memory      = 2048
-	initialization {
-		host_name = "vm-basic-1"
-		timezone = "Asia/Shanghai"
-		user_name = "root"
-		custom_script = "echo hello"
-		dns_search = "university.edu"
-		dns_servers = "8.8.8.8 8.8.4.4"
-	}
+  name        = "testAccVMBasic"
+  cluster_id  = "%s"
+  template_id = "%s"
+  memory      = 2048
+  initialization {
+    host_name     = "vm-basic-1"
+    timezone      = "Asia/Shanghai"
+    user_name     = "root"
+    custom_script = "echo hello"
+    dns_search    = "university.edu"
+    dns_servers   = "8.8.8.8 8.8.4.4"
+  }
 }
 `, clusterID, templateID)
 }
 
 const testAccVMBlockDevice = `
 resource "ovirt_vm" "vm" {
-	name        = "testAccVMBlockDevice"
-	cluster_id  = "5b6ab335-0251-028e-00ef-000000000326"
+  name       = "testAccVMBlockDevice"
+  cluster_id = "5b6ab335-0251-028e-00ef-000000000326"
 
-	initialization {
-		host_name = "vm-basic-1"
-		timezone = "Asia/Shanghai"
-		user_name = "root"
-		custom_script = "echo hello"
-		dns_search = "university.edu"
-		dns_servers = "8.8.8.8 8.8.4.4"
-		nic_configuration {
-			label       = "eth0"
-			boot_proto  = "static"
-			address  	= "10.1.60.60"
-			gateway     = "10.1.60.1"
-			netmask 	= "255.255.255.0"
-		}
-		nic_configuration {
-			label       = "eth1"
-			boot_proto  = "static"
-			address  	= "10.1.60.61"
-			gateway     = "10.1.60.1"
-			netmask 	= "255.255.255.0"
-		}
-	}
+  initialization {
+    host_name     = "vm-basic-1"
+    timezone      = "Asia/Shanghai"
+    user_name     = "root"
+    custom_script = "echo hello"
+    dns_search    = "university.edu"
+    dns_servers   = "8.8.8.8 8.8.4.4"
 
-	block_device {
-		disk_id = "${ovirt_disk.vm_disk.id}"
-		interface = "virtio"
-	}
+    nic_configuration {
+      label      = "eth0"
+      boot_proto = "static"
+      address    = "10.1.60.60"
+      gateway    = "10.1.60.1"
+      netmask    = "255.255.255.0"
+    }
+    nic_configuration {
+      label      = "eth1"
+      boot_proto = "static"
+      address    = "10.1.60.61"
+      gateway    = "10.1.60.1"
+      netmask    = "255.255.255.0"
+    }
+  }
+
+  block_device {
+    disk_id   = "${ovirt_disk.vm_disk.id}"
+    interface = "virtio"
+  }
 }
 
 resource "ovirt_disk" "vm_disk" {
-	name              = "vm_disk"
-	alias             = "vm_disk"
-	size              = 23687091200
-	format            = "cow"
-	storage_domain_id = "f78ab25e-ee16-42fe-80fa-b5f86b35524d"
-	sparse            = true
+  name              = "vm_disk"
+  alias             = "vm_disk"
+  size              = 23687091200
+  format            = "cow"
+  storage_domain_id = "f78ab25e-ee16-42fe-80fa-b5f86b35524d"
+  sparse            = true
 }
 `
 
 const testAccVMBlockDeviceUpdate = `
 resource "ovirt_vm" "vm" {
-	name        = "testAccVMBlockDevice"
-	cluster_id  = "5b6ab335-0251-028e-00ef-000000000326"
+  name       = "testAccVMBlockDevice"
+  cluster_id = "5b6ab335-0251-028e-00ef-000000000326"
 
-	initialization {
-		host_name = "vm-basic-updated"
-		timezone = "Asia/Shanghai"
-		user_name = "root"
-		custom_script = "echo hello2"
-		dns_search = "university.edu"
-		dns_servers = "8.8.8.8"
-		nic_configuration {
-			label       = "eth0"
-			boot_proto  = "static"
-			address  	= "10.1.60.66"
-			gateway     = "10.1.60.1"
-			netmask 	= "255.255.255.0"
-		}
-	}
+  initialization {
+    host_name     = "vm-basic-updated"
+    timezone      = "Asia/Shanghai"
+    user_name     = "root"
+    custom_script = "echo hello2"
+    dns_search    = "university.edu"
+    dns_servers   = "8.8.8.8"
+    nic_configuration {
+      label      = "eth0"
+      boot_proto = "static"
+      address    = "10.1.60.66"
+      gateway    = "10.1.60.1"
+      netmask    = "255.255.255.0"
+    }
+  }
 
-	block_device {
-		disk_id = "${ovirt_disk.vm_disk.id}"
-		interface = "virtio_scsi"
-	}
-
+  block_device {
+    disk_id   = "${ovirt_disk.vm_disk.id}"
+    interface = "virtio_scsi"
+  }
 }
 
 resource "ovirt_disk" "vm_disk" {
-	name              = "vm_disk"
-	alias             = "vm_disk"
-	size              = 23687091200
-	format            = "cow"
-	storage_domain_id = "f78ab25e-ee16-42fe-80fa-b5f86b35524d"
-	sparse            = true
+  name              = "vm_disk"
+  alias             = "vm_disk"
+  size              = 23687091200
+  format            = "cow"
+  storage_domain_id = "f78ab25e-ee16-42fe-80fa-b5f86b35524d"
+  sparse            = true
 }
 `
 
 func testAccVMTemplate(clusterID, templateID string) string {
 	return fmt.Sprintf(`
 resource "ovirt_vm" "vm" {
-	name        = "testAccVMTemplate"
-	cluster_id  = "%s"
-	template_id = "%s"
-	high_availability = true
+  name              = "testAccVMTemplate"
+  cluster_id        = "%s"
+  template_id       = "%s"
+  high_availability = true
 }
 `, clusterID, templateID)
 }
@@ -383,24 +383,23 @@ resource "ovirt_vm" "vm" {
 func testAccVMTemplateUpdate(clusterID, templateID string) string {
 	return fmt.Sprintf(`
 resource "ovirt_vm" "vm" {
-	name        = "testAccVMTemplate"
-	cluster_id  = "%s"
-	template_id = "%s"
+  name        = "testAccVMTemplate"
+  cluster_id  = "%s"
+  template_id = "%s"
 
-	block_device {
-		disk_id = "${ovirt_disk.vm_disk.id}"
-		interface = "virtio"
-	}
-
+  block_device {
+    disk_id   = "${ovirt_disk.vm_disk.id}"
+    interface = "virtio"
+  }
 }
 
 resource "ovirt_disk" "vm_disk" {
-	name              = "vm_disk"
-	alias             = "vm_disk"
-	size              = 23687091200
-	format            = "cow"
-	storage_domain_id = "f78ab25e-ee16-42fe-80fa-b5f86b35524d"
-	sparse            = true
+  name              = "vm_disk"
+  alias             = "vm_disk"
+  size              = 23687091200
+  format            = "cow"
+  storage_domain_id = "f78ab25e-ee16-42fe-80fa-b5f86b35524d"
+  sparse            = true
 }
 `, clusterID, templateID)
 }
@@ -408,11 +407,11 @@ resource "ovirt_disk" "vm_disk" {
 func testAccVMTemplateClone(clusterID, templateID string) string {
 	return fmt.Sprintf(`
 resource "ovirt_vm" "vm" {
-	name        = "testAccVMTemplate"
-	cluster_id  = "%s"
-	template_id = "%s"
-	high_availability = true
-	clone = true
+  name              = "testAccVMTemplate"
+  cluster_id        = "%s"
+  template_id       = "%s"
+  high_availability = true
+  clone             = true
 }
 `, clusterID, templateID)
 }
@@ -420,32 +419,31 @@ resource "ovirt_vm" "vm" {
 func testAccVMVnic(clusterID, templateID, vnicProfileID string) string {
 	return fmt.Sprintf(`
 resource "ovirt_vm" "vm" {
-	name        = "testAccVMVnic"
-	cluster_id  = "%s"
-	template_id = "%s"
+  name        = "testAccVMVnic"
+  cluster_id  = "%s"
+  template_id = "%s"
 }
 
 resource "ovirt_vnic" "vm_nic1" {
-	vm_id = "${ovirt_vm.vm.id}"
-	name = "nic1"
-	vnic_profile_id = "%s"
+  vm_id           = "${ovirt_vm.vm.id}"
+  name            = "nic1"
+  vnic_profile_id = "%s"
 }
-
 `, clusterID, templateID, vnicProfileID)
 }
 
 func testAccVMVnicUpdate(clusterID, templateID, vnicProfileID string) string {
 	return fmt.Sprintf(`
 resource "ovirt_vm" "vm" {
-	name        = "testAccVMVnic"
-	cluster_id  = "%s"
-	template_id = "%s"
+  name        = "testAccVMVnic"
+  cluster_id  = "%s"
+  template_id = "%s"
 }
 
 resource "ovirt_vnic" "vm_nic2" {
-	vm_id = "${ovirt_vm.vm.id}"
-	name = "nic2"
-	vnic_profile_id = "%s"
+  vm_id           = "${ovirt_vm.vm.id}"
+  name            = "nic2"
+  vnic_profile_id = "%s"
 }
 `, clusterID, templateID, vnicProfileID)
 }
@@ -453,10 +451,10 @@ resource "ovirt_vnic" "vm_nic2" {
 func testAccVMMemory(clusterID, templateID string) string {
 	return fmt.Sprintf(`
 resource "ovirt_vm" "vm" {
-	name        = "testAccVMMemory"
-	cluster_id  = "%s"
-	template_id = "%s"
-	high_availability = true
+  name              = "testAccVMMemory"
+  cluster_id        = "%s"
+  template_id       = "%s"
+  high_availability = true
 }
 `, clusterID, templateID)
 }
@@ -464,11 +462,11 @@ resource "ovirt_vm" "vm" {
 func testAccVMMemoryUpdate(clusterID, templateID string) string {
 	return fmt.Sprintf(`
 resource "ovirt_vm" "vm" {
-	name        = "testAccVMMemory"
-	cluster_id  = "%s"
-	template_id = "%s"
-	memory      = 2048
-	high_availability = true
+  name              = "testAccVMMemory"
+  cluster_id        = "%s"
+  template_id       = "%s"
+  memory            = 2048
+  high_availability = true
 }
 `, clusterID, templateID)
 }

--- a/ovirt/resource_ovirt_vnic_profile_test.go
+++ b/ovirt/resource_ovirt_vnic_profile_test.go
@@ -96,34 +96,34 @@ func testAccCheckOvirtVnicProfileExists(n string, v *ovirtsdk4.VnicProfile) reso
 
 const testAccVnicProfileBasic = `
 data "ovirt_networks" "ovirtmgmt-test" {
-	search {
-		criteria       = "datacenter = Default and name = ovirtmgmt-test"
-		max            = 1
-		case_sensitive = false
-	}
+  search {
+    criteria       = "datacenter = Default and name = ovirtmgmt-test"
+    max            = 1
+    case_sensitive = false
+  }
 }
 
 resource "ovirt_vnic_profile" "profile" {
-	name        	= "testAccOvirtVnicProfileBasic"
-	network_id  	= "${data.ovirt_networks.ovirtmgmt-test.networks.0.id}"
-	migratable  	= false
-	port_mirroring 	= false
+  name        	 = "testAccOvirtVnicProfileBasic"
+  network_id  	 = "${data.ovirt_networks.ovirtmgmt-test.networks.0.id}"
+  migratable  	 = false
+  port_mirroring = false
 }
 `
 
 const testAccVnicProfileBasicUpdate = `
 data "ovirt_networks" "ovirtmgmt-test" {
-	search {
-		criteria       = "datacenter = Default and name = ovirtmgmt-test"
-		max            = 1
-		case_sensitive = false
-	}
+  search {
+    criteria       = "datacenter = Default and name = ovirtmgmt-test"
+    max            = 1
+    case_sensitive = false
+  }
 }
 
 resource "ovirt_vnic_profile" "profile" {
-	name        	= "testAccOvirtVnicProfileBasicUpdate"
-	network_id  	= "${data.ovirt_networks.ovirtmgmt-test.networks.0.id}"
-	migratable  	= true
-	port_mirroring 	= true
+  name        	 = "testAccOvirtVnicProfileBasicUpdate"
+  network_id  	 = "${data.ovirt_networks.ovirtmgmt-test.networks.0.id}"
+  migratable  	 = true
+  port_mirroring = true
 }
 `

--- a/ovirt/resource_ovirt_vnic_test.go
+++ b/ovirt/resource_ovirt_vnic_test.go
@@ -112,16 +112,16 @@ func testAccCheckOvirtVnicExists(n string, v *ovirtsdk4.Nic) resource.TestCheckF
 
 const testAccVnicBasic = `
 resource "ovirt_vnic" "nic" {
-	name        	= "testAccOvirtVnicBasic"
-	vm_id			= "1a4bc4d8-fec7-4fe4-b01a-7d1185854c39"
-	vnic_profile_id = "0000000a-000a-000a-000a-000000000398"
+  name            = "testAccOvirtVnicBasic"
+  vm_id           = "1a4bc4d8-fec7-4fe4-b01a-7d1185854c39"
+  vnic_profile_id = "0000000a-000a-000a-000a-000000000398"
 }
 `
 
 const testAccVnicBasicUpdate = `
 resource "ovirt_vnic" "nic" {
-	name        	= "testAccOvirtVnicBasicUpdate"
-	vm_id			= "77f7e0d9-6105-492f-92e8-06b989211e46"
-	vnic_profile_id = "0000000a-000a-000a-000a-000000000398"
+  name            = "testAccOvirtVnicBasicUpdate"
+  vm_id           = "77f7e0d9-6105-492f-92e8-06b989211e46"
+  vnic_profile_id = "0000000a-000a-000a-000a-000000000398"
 }
 `


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #159 .

Changes proposed in this pull request:

* Set 2 whitespaces as the indentation for HCL code snippets
* Each config option is aligned vertically by equal sign

