### PR TITLE
resource/ovirt_disk_attachment: Correct checking if a disk attachment has been destroyed

### DIFF
--- a/ovirt/resource_ovirt_disk_attachment.go
+++ b/ovirt/resource_ovirt_disk_attachment.go
@@ -134,7 +134,7 @@ func resourceOvirtDiskAttachmentCreate(d *schema.ResourceData, meta interface{})
 func resourceOvirtDiskAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
 
-	vmID, diskID, err := getVMIDAndDiskID(d, meta)
+	vmID, diskID, err := getVMIDAndDiskID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func resourceOvirtDiskAttachmentRead(d *schema.ResourceData, meta interface{}) e
 	conn := meta.(*ovirtsdk4.Connection)
 	// Disk ID is equals to its relevant Disk Attachment ID
 	// Sess: https://github.com/oVirt/ovirt-engine/blob/68753f46f09419ddcdbb632453501273697d1a20/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/DiskAttachmentMapper.java
-	vmID, diskID, err := getVMIDAndDiskID(d, meta)
+	vmID, diskID, err := getVMIDAndDiskID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func resourceOvirtDiskAttachmentRead(d *schema.ResourceData, meta interface{}) e
 func resourceOvirtDiskAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
 
-	vmID, diskID, err := getVMIDAndDiskID(d, meta)
+	vmID, diskID, err := getVMIDAndDiskID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -267,8 +267,8 @@ func resourceOvirtDiskAttachmentDelete(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func getVMIDAndDiskID(d *schema.ResourceData, meta interface{}) (string, string, error) {
-	parts := strings.Split(d.Id(), ":")
+func getVMIDAndDiskID(rsID string) (string, string, error) {
+	parts := strings.Split(rsID, ":")
 	if len(parts) != 2 {
 		return "", "", fmt.Errorf("Invalid resource id")
 	}


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #161 

Changes proposed in this pull request:

* Parse the `rs.Primary.ID` into respective ID of vm and disk-attachment and then check the existence of the specific disk-attachment
* Change the parameters of function `getVMIDAndDiskID()` to better fit for general purpose

Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtDiskAttachment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtDiskAttachment_basic -timeout 180m
=== RUN   TestAccOvirtDiskAttachment_basic
--- PASS: TestAccOvirtDiskAttachment_basic (2.66s)
PASS
ok      github.com/ovirt/terraform-provider-ovirt/ovirt 2.695s
```
