### PR TITLE
Add general purpose function to parse resource ID

### DIFF
--- a/ovirt/resource_ovirt_disk_attachment.go
+++ b/ovirt/resource_ovirt_disk_attachment.go
@@ -7,9 +7,7 @@
 package ovirt
 
 import (
-	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -134,10 +132,11 @@ func resourceOvirtDiskAttachmentCreate(d *schema.ResourceData, meta interface{})
 func resourceOvirtDiskAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
 
-	vmID, diskID, err := getVMIDAndDiskID(d.Id())
+	parts, err := parseResourceID(d.Id(), 2)
 	if err != nil {
 		return err
 	}
+	vmID, diskID := parts[0], parts[1]
 
 	paramDiskAttachment := ovirtsdk4.NewDiskAttachmentBuilder()
 	attributeUpdate := false
@@ -173,10 +172,11 @@ func resourceOvirtDiskAttachmentRead(d *schema.ResourceData, meta interface{}) e
 	conn := meta.(*ovirtsdk4.Connection)
 	// Disk ID is equals to its relevant Disk Attachment ID
 	// Sess: https://github.com/oVirt/ovirt-engine/blob/68753f46f09419ddcdbb632453501273697d1a20/backend/manager/modules/restapi/types/src/main/java/org/ovirt/engine/api/restapi/types/DiskAttachmentMapper.java
-	vmID, diskID, err := getVMIDAndDiskID(d.Id())
+	parts, err := parseResourceID(d.Id(), 2)
 	if err != nil {
 		return err
 	}
+	vmID, diskID := parts[0], parts[1]
 	d.Set("vm_id", vmID)
 	d.Set("disk_id", diskID)
 
@@ -211,10 +211,11 @@ func resourceOvirtDiskAttachmentRead(d *schema.ResourceData, meta interface{}) e
 func resourceOvirtDiskAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
 
-	vmID, diskID, err := getVMIDAndDiskID(d.Id())
+	parts, err := parseResourceID(d.Id(), 2)
 	if err != nil {
 		return err
 	}
+	vmID, diskID := parts[0], parts[1]
 
 	diskAttachmentService := conn.SystemService().
 		VmsService().
@@ -265,14 +266,6 @@ func resourceOvirtDiskAttachmentDelete(d *schema.ResourceData, meta interface{})
 		return err
 	}
 	return nil
-}
-
-func getVMIDAndDiskID(rsID string) (string, string, error) {
-	parts := strings.Split(rsID, ":")
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("Invalid resource id")
-	}
-	return parts[0], parts[1], nil
 }
 
 // DiskAttachmentStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch

--- a/ovirt/resource_ovirt_disk_attachment_test.go
+++ b/ovirt/resource_ovirt_disk_attachment_test.go
@@ -55,10 +55,11 @@ func testAccCheckDiskAttachmentDestroy(s *terraform.State) error {
 			continue
 		}
 
-		vmID, diskID, err := getVMIDAndDiskID(rs.Primary.ID)
+		parts, err := parseResourceID(rs.Primary.ID, 2)
 		if err != nil {
 			return err
 		}
+		vmID, diskID := parts[0], parts[1]
 
 		getResp, err := conn.SystemService().VmsService().
 			VmService(vmID).
@@ -89,10 +90,11 @@ func testAccCheckOvirtDiskAttachmentExists(n string, diskAttachment *ovirtsdk4.D
 			return fmt.Errorf("No Disk attachment ID is set")
 		}
 
-		vmID, diskID, err := getVMIDAndDiskID(rs.Primary.ID)
+		parts, err := parseResourceID(rs.Primary.ID, 2)
 		if err != nil {
 			return err
 		}
+		vmID, diskID := parts[0], parts[1]
 
 		conn := testAccProvider.Meta().(*ovirtsdk4.Connection)
 		getResp, err := conn.SystemService().VmsService().

--- a/ovirt/resource_ovirt_snapshot_test.go
+++ b/ovirt/resource_ovirt_snapshot_test.go
@@ -42,10 +42,11 @@ func testAccCheckSnapshotDestroy(s *terraform.State) error {
 			continue
 		}
 
-		vmID, snapshotID, err := getVMIDAndSnapshotID(rs.Primary.ID)
+		parts, err := parseResourceID(rs.Primary.ID, 2)
 		if err != nil {
 			return err
 		}
+		vmID, snapshotID := parts[0], parts[1]
 
 		getResp, err := conn.SystemService().
 			VmsService().
@@ -78,10 +79,11 @@ func testAccCheckOvirtSnapshotExists(n string, v *ovirtsdk4.Snapshot) resource.T
 			return fmt.Errorf("No Snapshot ID is set")
 		}
 
-		vmID, snapshotID, err := getVMIDAndSnapshotID(rs.Primary.ID)
+		parts, err := parseResourceID(rs.Primary.ID, 2)
 		if err != nil {
 			return err
 		}
+		vmID, snapshotID := parts[0], parts[1]
 
 		conn := testAccProvider.Meta().(*ovirtsdk4.Connection)
 		getResp, err := conn.SystemService().

--- a/ovirt/resource_ovirt_vnic.go
+++ b/ovirt/resource_ovirt_vnic.go
@@ -9,7 +9,6 @@ package ovirt
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	ovirtsdk4 "github.com/ovirt/go-ovirt"
@@ -75,10 +74,11 @@ func resourceOvirtVnicCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceOvirtVnicRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
-	vmID, vnicID, err := getVMIDAndNicID(d.Id())
+	parts, err := parseResourceID(d.Id(), 2)
 	if err != nil {
 		return err
 	}
+	vmID, vnicID := parts[0], parts[1]
 	d.Set("vm_id", vmID)
 
 	getVnicResp, err := conn.SystemService().
@@ -104,10 +104,11 @@ func resourceOvirtVnicRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceOvirtVnicDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
-	vmID, vnicID, err := getVMIDAndNicID(d.Id())
+	parts, err := parseResourceID(d.Id(), 2)
 	if err != nil {
 		return err
 	}
+	vmID, vnicID := parts[0], parts[1]
 
 	nicService := conn.SystemService().
 		VmsService().
@@ -133,12 +134,4 @@ func resourceOvirtVnicDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	return nil
-}
-
-func getVMIDAndNicID(id string) (string, string, error) {
-	parts := strings.Split(id, ":")
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("Invalid resource id")
-	}
-	return parts[0], parts[1], nil
 }

--- a/ovirt/resource_ovirt_vnic_test.go
+++ b/ovirt/resource_ovirt_vnic_test.go
@@ -51,11 +51,11 @@ func testAccCheckVnicDestroy(s *terraform.State) error {
 		if rs.Type != "ovirt_vnic" {
 			continue
 		}
-
-		vmID, nicID, err := getVMIDAndNicID(rs.Primary.ID)
+		parts, err := parseResourceID(rs.Primary.ID, 2)
 		if err != nil {
 			return err
 		}
+		vmID, nicID := parts[0], parts[1]
 
 		getResp, err := conn.SystemService().VmsService().
 			VmService(vmID).
@@ -86,10 +86,11 @@ func testAccCheckOvirtVnicExists(n string, v *ovirtsdk4.Nic) resource.TestCheckF
 			return fmt.Errorf("No Vnic ID is set")
 		}
 
-		vmID, nicID, err := getVMIDAndNicID(rs.Primary.ID)
+		parts, err := parseResourceID(rs.Primary.ID, 2)
 		if err != nil {
 			return err
 		}
+		vmID, nicID := parts[0], parts[1]
 
 		conn := testAccProvider.Meta().(*ovirtsdk4.Connection)
 		getResp, err := conn.SystemService().VmsService().

--- a/ovirt/utils.go
+++ b/ovirt/utils.go
@@ -55,3 +55,12 @@ func macRange() schema.SchemaValidateFunc {
 
 	}
 }
+
+func parseResourceID(id string, count int) ([]string, error) {
+	parts := strings.Split(id, ":")
+
+	if len(parts) != count {
+		return nil, fmt.Errorf("Invalid Resource ID %s, expected %d parts, got %d", id, count, len(parts))
+	}
+	return parts, nil
+}

--- a/ovirt/utils_test.go
+++ b/ovirt/utils_test.go
@@ -1,0 +1,56 @@
+package ovirt
+
+import "testing"
+
+func TestParseResourceID(t *testing.T) {
+	validResourceID := []struct {
+		ResourceID string
+		Count      int
+	}{
+		{
+			"08f9d3ec-5768-479f-aa16-d2d9934b356a:8daea363-7535-4af3-a80f-e0f6c02666e0",
+			2,
+		},
+		{
+			"24252dc8-2a5a-4871-9601-7486a775d0e3:f59d3de3-512e-4eb3-9f4b-0e2395297b7c:8daea363-7535-4af3-a80f-e0f6c02666e0",
+			3,
+		},
+		{
+			"df18a81a-02eb-476e-bd42-bf87cbd5b948:615bdbb1-4d2a-443d-8ede-4f15b141603c:4104093f-5ba8-4d9f-849b-e4ad75143be7:7e8f03c7-0ac0-40b8-9497-9c64d4001f54",
+			4,
+		},
+	}
+
+	for _, v := range validResourceID {
+		_, err := parseResourceID(v.ResourceID, v.Count)
+		if err != nil {
+			t.Fatalf("%s should be a valid Resource ID: %s", v.ResourceID, err)
+		}
+	}
+
+	invalidResourceID := []struct {
+		ResourceID string
+		Count      int
+	}{
+		{
+			"08f9d3ec-5768-479f-aa16-d2d9934b356a:8daea363-7535-4af3-a80f-e0f6c02666e0",
+			3,
+		},
+		{
+			"24252dc8-2a5a-4871-9601-7486a775d0e3:f59d3de3-512e-4eb3-9f4b-0e2395297b7c:8daea363-7535-4af3-a80f-e0f6c02666e0",
+			2,
+		},
+		{
+			"df18a81a-02eb-476e-bd42-bf87cbd5b948:615bdbb1-4d2a-443d-8ede-4f15b141603c:4104093f-5ba8-4d9f-849b-e4ad75143be7:7e8f03c7-0ac0-40b8-9497-9c64d4001f54",
+			5,
+		},
+	}
+
+	for _, v := range invalidResourceID {
+		_, err := parseResourceID(v.ResourceID, v.Count)
+		if err == nil {
+			t.Fatalf("%s should be an invalid Resource ID: %s", v.ResourceID, err)
+		}
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>


Changes proposed in this pull request:

* Add a general helper function named `parseResourceID` to parse combined resource ID
* Remove the legacy `getXXIDAndYYID` functions and use new `parseResourceID` function instead
* Add test case for this new function

Output from testing:

```
$ go test ./ovirt -run "TestParseResourceID" -v
=== RUN   TestParseResourceID
--- PASS: TestParseResourceID (0.00s)
PASS
ok  	github.com/ovirt/terraform-provider-ovirt/ovirt	0.020s
```




