### PR TITLE
Format inline HCL codes in docs

### DIFF
--- a/website/docs/d/clusters.html.markdown
+++ b/website/docs/d/clusters.html.markdown
@@ -14,13 +14,13 @@ The oVirt Clusters data source allows access to details of list of clusters with
 
 ```hcl
 data "ovirt_clusters" "filtered_clusters" {
-    name_regex = "^default*"
-	
-    search     = {
-	  criteria       = "architecture = x86_64 and Storage.name = data"
-	  max            = 2
-	  case_sensitive = false
-	}
+  name_regex = "^default*"
+
+  search = {
+    criteria       = "architecture = x86_64 and Storage.name = data"
+    max            = 2
+    case_sensitive = false
+  }
 }
 ```
 

--- a/website/docs/d/datacenters.html.markdown
+++ b/website/docs/d/datacenters.html.markdown
@@ -14,13 +14,13 @@ The oVirt Datacenters data source allows access to details of list of datacenter
 
 ```hcl
 data "ovirt_datacenters" "filtered_datacenters" {
-    name_regex = "^default*"
-	
-    search     = {
-	  criteria       = "status = up and Storage.name = data"
-	  max            = 2
-	  case_sensitive = false
-	}
+  name_regex = "^default*"
+
+  search = {
+    criteria       = "status = up and Storage.name = data"
+    max            = 2
+    case_sensitive = false
+  }
 }
 ```
 

--- a/website/docs/d/disks.html.markdown
+++ b/website/docs/d/disks.html.markdown
@@ -14,13 +14,13 @@ The oVirt Disks data source allows access to details of list of disks within oVi
 
 ```hcl
 data "ovirt_disks" "filtered_disks" {
-    name_regex = "^test_disk*"
+  name_regex = "^test_disk*"
 
-    search     = {
-	  criteria       = "name = test_disk1 and provisioned_size > 1024000000"
-	  max            = 2
-	  case_sensitive = false
-	}
+  search = {
+    criteria       = "name = test_disk1 and provisioned_size > 1024000000"
+    max            = 2
+    case_sensitive = false
+  }
 }
 ```
 

--- a/website/docs/d/networks.html.markdown
+++ b/website/docs/d/networks.html.markdown
@@ -14,13 +14,13 @@ The oVirt Networks data source allows access to details of list of networks with
 
 ```hcl
 data "ovirt_networks" "filtered_networks" {
-    name_regex = "^ovirtmgmt-t*"
-	
-    search     = {
-	  criteria       = "datacenter = Default and name = ovirtmgmt-test"
-	  max            = 2
-	  case_sensitive = false
-	}
+  name_regex = "^ovirtmgmt-t*"
+
+  search = {
+    criteria       = "datacenter = Default and name = ovirtmgmt-test"
+    max            = 2
+    case_sensitive = false
+  }
 }
 ```
 

--- a/website/docs/d/storagedomains.html.markdown
+++ b/website/docs/d/storagedomains.html.markdown
@@ -14,13 +14,13 @@ The oVirt Storagedomains data source allows access to details of list of storage
 
 ```hcl
 data "ovirt_storagedomains" "filtered_storagedomains" {
-    name_regex = "^MAIN_dat.*|^DEV_dat.*"
+  name_regex = "^MAIN_dat.*|^DEV_dat.*"
 
-    search     = {
-	  criteria       = "status != unattached and name = DS_INTERNAL and datacenter = MY_DC"
-	  max            = 2
-	  case_sensitive = false
-	}
+  search = {
+    criteria       = "status != unattached and name = DS_INTERNAL and datacenter = MY_DC"
+    max            = 2
+    case_sensitive = false
+  }
 }
 ```
 

--- a/website/docs/d/vnic_profiles.html.markdown
+++ b/website/docs/d/vnic_profiles.html.markdown
@@ -14,8 +14,8 @@ The oVirt vNIC profiles data source allows access to details of list of vNIC pro
 
 ```hcl
 data "ovirt_vnic_profiles" "filtered_vnic_profiles" {
-	name_regex = ".*mirror$"
-	network_id = "649f2d61-7f23-477b-93bd-d55f974d8bc8"
+  name_regex = ".*mirror$"
+  network_id = "649f2d61-7f23-477b-93bd-d55f974d8bc8"
 }
 ```
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -19,15 +19,15 @@ provider "ovirt" {
   url      = "https://engine-api/ovirt-engine/api"
   username = "admin@internal"
   password = "thepassword"
-  headers  {
-      filter      = true
-      all_content = true
+  headers {
+    filter      = true
+    all_content = true
   }
 }
 
 # Create a VM
 resource "ovirt_vm" "test-vm" {
-    # ...
+  # ...
 }
 ```
 

--- a/website/docs/r/vm.html.markdown
+++ b/website/docs/r/vm.html.markdown
@@ -16,9 +16,9 @@ Manages a VM resource within oVirt.
 
 ```hcl
 resource "ovirt_vm" "vm" {
-  name        = "my_vm"
-  cluster_id  = "3e7e71ed-24ea-4812-8ef9-a09a858d31e4"
-  memory      = 4096
+  name       = "my_vm"
+  cluster_id = "3e7e71ed-24ea-4812-8ef9-a09a858d31e4"
+  memory     = 4096
   # there has one or more disks in the specified template
   template_id = "5ba458ca-00a4-0358-00cb-000000000223"
 }
@@ -28,9 +28,9 @@ resource "ovirt_vm" "vm" {
 
 ```hcl
 resource "ovirt_vm" "vm" {
-  name        = "my_vm"
-  cluster_id  = "3e7e71ed-24ea-4812-8ef9-a09a858d31e4"
-  memory      = 4096                    # in megabytes
+  name       = "my_vm"
+  cluster_id = "3e7e71ed-24ea-4812-8ef9-a09a858d31e4"
+  memory     = 4096 # in megabytes
 
   block_device {
     disk_id   = "${ovirt_disk.boot_disk_1.id}"
@@ -42,7 +42,7 @@ resource "ovirt_vm" "vm" {
 resource "ovirt_disk" "boot_disk_1" {
   name              = "boot_disk_1"
   alias             = "boot_disk_1"
-  size              = 60                  # in gigabytes
+  size              = 60 # in gigabytes
   format            = "cow"
   storage_domain_id = "5ba458ca-00a4-0358-00cb-000000000223"
   sparse            = true
@@ -53,9 +53,9 @@ resource "ovirt_disk" "boot_disk_1" {
 
 ```hcl
 resource "ovirt_vm" "vm" {
-  name        = "my_vm"
-  cluster_id  = "3e7e71ed-24ea-4812-8ef9-a09a858d31e4"
-  memory      = 4096                    # in megabytes
+  name       = "my_vm"
+  cluster_id = "3e7e71ed-24ea-4812-8ef9-a09a858d31e4"
+  memory     = 4096 # in megabytes
 
   block_device {
     disk_id   = "${data.boot_disk.disks.0.id}"
@@ -65,7 +65,7 @@ resource "ovirt_vm" "vm" {
 }
 
 data "ovirt_disks" "boot_disk" {
-    name_regex = "boot_disk_1"
+  name_regex = "boot_disk_1"
 }
 ```
 
@@ -73,9 +73,9 @@ data "ovirt_disks" "boot_disk" {
 
 ```hcl
 resource "ovirt_vm" "vm" {
-  name        = "my_vm"
-  cluster_id  = "3e7e71ed-24ea-4812-8ef9-a09a858d31e4"
-  memory      = 4096                      # in megabytes
+  name       = "my_vm"
+  cluster_id = "3e7e71ed-24ea-4812-8ef9-a09a858d31e4"
+  memory     = 4096 # in megabytes
   # there has one or more disks in the specified template
   template_id = "5ba458ca-00a4-0358-00cb-000000000223"
 }
@@ -83,7 +83,7 @@ resource "ovirt_vm" "vm" {
 resource "ovirt_disk" "attached_disk_1" {
   name              = "attached_disk_1"
   alias             = "attached_disk_1"
-  size              = 60                  # in gigabytes
+  size              = 60 # in gigabytes
   format            = "cow"
   storage_domain_id = "5ba458ca-00a4-0358-00cb-000000000223"
   sparse            = true
@@ -103,9 +103,9 @@ resource "ovirt_disk_attachment" "attachment" {
 
 ```hcl
 resource "ovirt_vm" "vm" {
-  name        = "my_vm"
-  cluster_id  = "3e7e71ed-24ea-4812-8ef9-a09a858d31e4"
-  memory      = 4096                    # in megabytes
+  name       = "my_vm"
+  cluster_id = "3e7e71ed-24ea-4812-8ef9-a09a858d31e4"
+  memory     = 4096 # in megabytes
   # there has one or more disks in the specified template
   template_id = "5ba458ca-00a4-0358-00cb-000000000223"
 }
@@ -130,16 +130,16 @@ resource "ovirt_vm" "my_vm_1" {
   name        = "my_vm_1"
   cluster_id  = "b0280bd4-4152-42ad-aa37-1e73ab30b0da"
   template_id = "5ba458ca-00a4-0358-00cb-000000000223"
-  memory      = 4096                         # in megabytes
+  memory      = 4096 # in megabytes
 
   initialization {
     authorized_ssh_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"
-	host_name          = "vm-basic-updated"
-	timezone           = "Asia/Shanghai"
-	user_name          = "root"
-	custom_script      = "echo hello2"
-	dns_search         = "university.edu"
-	dns_servers        = "8.8.8.8"
+    host_name          = "vm-basic-updated"
+    timezone           = "Asia/Shanghai"
+    user_name          = "root"
+    custom_script      = "echo hello2"
+    dns_search         = "university.edu"
+    dns_servers        = "8.8.8.8"
 
     nic_configuration {
       label      = "eth0"


### PR DESCRIPTION
Along with the new Terraform v0.12, Terraform also introduces the recommended [Idiomatic Style Conventions](https://www.terraform.io/docs/configuration/style.html) for HCL languages. Besides the HCL explicitly defined in `.tf` and . `.tfvars`, the inline HCLs in docs should also follow that rule. 

This PR is trying to convert all the existing inline HCL codes into the canonical format. I made a tool https://github.com/imjoey/md-code-formatter for doing this.

Signed-off-by: imjoey <majunjiev@gmail.com>

