### PR TITLE
resource/ovirt_vm: Do not change VM status after updating

### DIFF
--- a/ovirt/resource_ovirt_vm.go
+++ b/ovirt/resource_ovirt_vm.go
@@ -447,25 +447,6 @@ func resourceOvirtVMUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	// Any way, ensure the VM is UP
-
-	// Currently only support cloud-init for Linux VMs
-	_, useCloudInit := d.GetOk("initialization")
-	vmService.Start().UseCloudInit(useCloudInit).Send()
-
-	upStateConf := &resource.StateChangeConf{
-		Target:     []string{string(ovirtsdk4.VMSTATUS_DOWN)},
-		Refresh:    VMStateRefreshFunc(conn, d.Id()),
-		Timeout:    d.Timeout(schema.TimeoutUpdate),
-		Delay:      10 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-	_, err := upStateConf.WaitForState()
-	if err != nil {
-		log.Printf("[DEBUG] Failed to wait for VM (%s) to become down: %s", d.Id(), err)
-		return fmt.Errorf("Error starting vm: %s", err)
-	}
-
 	d.Partial(false)
 	return resourceOvirtVMRead(d, meta)
 }

--- a/ovirt/resource_ovirt_vm_test.go
+++ b/ovirt/resource_ovirt_vm_test.go
@@ -30,6 +30,17 @@ func TestAccOvirtVM_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("ovirt_vm.vm", "name", "testAccVMBasic"),
 					resource.TestCheckResourceAttr("ovirt_vm.vm", "status", "up"),
 					resource.TestCheckResourceAttr("ovirt_vm.vm", "memory", "2048"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.dns_servers", "8.8.8.8 8.8.4.4"),
+				),
+			},
+			{
+				Config: testAccVMBasicUpdate(clusterID, templateID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtVMExists("ovirt_vm.vm", &vm),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "name", "testAccVMBasic"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "status", "up"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "memory", "2048"),
+					resource.TestCheckResourceAttr("ovirt_vm.vm", "initialization.0.dns_servers", "114.114.114.114"),
 				),
 			},
 		},
@@ -284,6 +295,25 @@ resource "ovirt_vm" "vm" {
     dns_servers   = "8.8.8.8 8.8.4.4"
   }
 }
+`, clusterID, templateID)
+}
+
+func testAccVMBasicUpdate(clusterID, templateID string) string {
+	return fmt.Sprintf(`
+resource "ovirt_vm" "vm" {
+	name        = "testAccVMBasic"
+	cluster_id  = "%s"
+	template_id = "%s"
+	memory      = 2048
+	initialization {
+	  host_name     = "vm-basic-1"
+	  timezone      = "Asia/Shanghai"
+	  user_name     = "root"
+	  custom_script = "echo hello"
+	  dns_search    = "university.edu"
+	  dns_servers   = "114.114.114.114"
+	}
+  }
 `, clusterID, templateID)
 }
 


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Issue #166 .

Changes proposed in this pull request:

* After updating a VM, keep its original status without starting it
* Improve the acceptance test cases for resource vm

Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtVM_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtVM_basic -timeout 180m
=== RUN   TestAccOvirtVM_basic
--- PASS: TestAccOvirtVM_basic (94.16s)
PASS
ok      github.com/ovirt/terraform-provider-ovirt/ovirt 94.183s
```
