### PR TITLE
add the ability to specify the mac address during vnic creation

### DIFF
--- a/ovirt/resource_ovirt_vnic.go
+++ b/ovirt/resource_ovirt_vnic.go
@@ -38,6 +38,11 @@ func resourceOvirtVnic() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"vnic_mac_addr": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -53,6 +58,10 @@ func resourceOvirtVnicCreate(d *schema.ResourceData, meta interface{}) error {
 		Nic(
 			ovirtsdk4.NewNicBuilder().
 				Name(d.Get("name").(string)).
+				Mac(
+					ovirtsdk4.NewMacBuilder().
+						Address(d.Get("vnic_mac_addr").(string)).
+						MustBuild()).
 				VnicProfile(
 					ovirtsdk4.NewVnicProfileBuilder().
 						Id(d.Get("vnic_profile_id").(string)).
@@ -98,6 +107,7 @@ func resourceOvirtVnicRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", getVnicResp.MustNic().MustName())
 	d.Set("vnic_profile_id", getVnicResp.MustNic().MustVnicProfile().MustId())
+	d.Set("vnic_mac_addr", getVnicResp.MustNic().MustMac().MustAddress())
 
 	return nil
 }

--- a/ovirt/resource_ovirt_vnic_test.go
+++ b/ovirt/resource_ovirt_vnic_test.go
@@ -45,6 +45,38 @@ func TestAccOvirtVnic_basic(t *testing.T) {
 	})
 }
 
+func TestAccOvirtVnic_mac(t *testing.T) {
+	var nic ovirtsdk4.Nic
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckVnicDestroy,
+		IDRefreshName: "ovirt_vnic.nic",
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVnicMac,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtVnicExists("ovirt_vnic.nic", &nic),
+					resource.TestCheckResourceAttr("ovirt_vnic.nic", "name", "testAccOvirtVnicBasic"),
+					resource.TestCheckResourceAttr("ovirt_vnic.nic", "vm_id", "1a4bc4d8-fec7-4fe4-b01a-7d1185854c39"),
+					resource.TestCheckResourceAttr("ovirt_vnic.nic", "vnic_profile_id", "0000000a-000a-000a-000a-000000000398"),
+					resource.TestCheckResourceAttr("ovirt_vnic.nic", "vnic_mac_addr", "00:11:22:33:44:55"),
+				),
+			},
+			{
+				Config: testAccVnicMacUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtVnicExists("ovirt_vnic.nic", &nic),
+					resource.TestCheckResourceAttr("ovirt_vnic.nic", "name", "testAccOvirtVnicBasicUpdate"),
+					resource.TestCheckResourceAttr("ovirt_vnic.nic", "vm_id", "77f7e0d9-6105-492f-92e8-06b989211e46"),
+					resource.TestCheckResourceAttr("ovirt_vnic.nic", "vnic_profile_id", "0000000a-000a-000a-000a-000000000398"),
+					resource.TestCheckResourceAttr("ovirt_vnic.nic", "vnic_mac_addr", "00:11:22:33:44:66"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckVnicDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*ovirtsdk4.Connection)
 	for _, rs := range s.RootModule().Resources {
@@ -124,5 +156,22 @@ resource "ovirt_vnic" "nic" {
   name            = "testAccOvirtVnicBasicUpdate"
   vm_id           = "77f7e0d9-6105-492f-92e8-06b989211e46"
   vnic_profile_id = "0000000a-000a-000a-000a-000000000398"
+}
+`
+const testAccVnicMac = `
+resource "ovirt_vnic" "nic" {
+  name            = "testAccOvirtVnicBasic"
+  vm_id           = "1a4bc4d8-fec7-4fe4-b01a-7d1185854c39"
+  vnic_profile_id = "0000000a-000a-000a-000a-000000000398"
+  vnic_mac_addr   = "00:11:22:33:44:55"
+}
+`
+
+const testAccVnicMacUpdate = `
+resource "ovirt_vnic" "nic" {
+  name            = "testAccOvirtVnicBasic"
+  vm_id           = "1a4bc4d8-fec7-4fe4-b01a-7d1185854c39"
+  vnic_profile_id = "0000000a-000a-000a-000a-000000000398"
+  vnic_mac_addr   = "00:11:22:33:44:66"
 }
 `


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Add mac address attribute to vnic creation

Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtDataCenter_'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtDataCenter_ -timeout 180m
=== RUN   TestAccOvirtDataCenter_basic
--- PASS: TestAccOvirtDataCenter_basic (1.73s)
PASS
ok      github.com/ovirt/terraform-provider-ovirt/ovirt 1.757s
```
