### PR TITLE
resource/ovirt_datacenter: Make the status field exportable

### DIFF
--- a/ovirt/resource_ovirt_datacenter.go
+++ b/ovirt/resource_ovirt_datacenter.go
@@ -37,6 +37,10 @@ func resourceOvirtDataCenter() *schema.Resource {
 				Required: true,
 				ForceNew: false,
 			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -127,6 +131,7 @@ func resourceOvirtDataCenterRead(d *schema.ResourceData, meta interface{}) error
 	if description, ok := datacenter.Description(); ok {
 		d.Set("description", description)
 	}
+	d.Set("status", string(datacenter.MustStatus()))
 
 	return nil
 }

--- a/ovirt/resource_ovirt_datacenter_test.go
+++ b/ovirt/resource_ovirt_datacenter_test.go
@@ -29,6 +29,7 @@ func TestAccOvirtDataCenter_basic(t *testing.T) {
 					testAccCheckOvirtDataCenterExists("ovirt_datacenter.datacenter", &dc),
 					resource.TestCheckResourceAttr("ovirt_datacenter.datacenter", "name", "testAccOvirtDataCenterBasic"),
 					resource.TestCheckResourceAttr("ovirt_datacenter.datacenter", "local", "false"),
+					resource.TestCheckResourceAttrSet("ovirt_datacenter.datacenter", "status"),
 				),
 			},
 			{

--- a/website/docs/r/datacenter.html.markdown
+++ b/website/docs/r/datacenter.html.markdown
@@ -30,11 +30,10 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `name` - See Argument Reference above
-* `description` - See Argument Reference above
-* `local` - See Argument Reference above
+* `id` - The identifier for the datacenter.
+* `status` - The current status of the datacenter, possible values are `contend`, `maintenance`, `not_operational`, `problematic`, `uninitialized` and `up`.
 
 ## Import
 


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>


Changes proposed in this pull request:

* Add support for new `status` field marked as `computed`
* Make acceptance testing for the new field
* Add relevant docs

Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtDataCenter_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtDataCenter_basic -timeout 180m
=== RUN   TestAccOvirtDataCenter_basic
--- PASS: TestAccOvirtDataCenter_basic (1.43s)
PASS
ok      github.com/ovirt/terraform-provider-ovirt/ovirt 1.453s
...
```
