### PR TITLE
New Data Source: ovirt_nics

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Provider Usage
 ```HCL
 provider "ovirt" {
   username = "username@profile"
-  url = "https://ovirt/ovirt-engine/api"
+  url      = "https://ovirt/ovirt-engine/api"
   password = "Password"
 }
 ```
@@ -76,6 +76,7 @@ provider "ovirt" {
   * ovirt_hosts
   * ovirt_mac_pools
   * ovirt_networks
+  * ovirt_nics
   * ovirt_storagedomains
   * ovirt_users
   * ovirt_vms

--- a/ovirt/data_source_ovirt_nics.go
+++ b/ovirt/data_source_ovirt_nics.go
@@ -1,0 +1,264 @@
+package ovirt
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func dataSourceOvirtNics() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceOvirtNicsRead,
+		Schema: map[string]*schema.Schema{
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.ValidateRegexp,
+			},
+			"vm_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"nics": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"boot_protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"comment": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"interface": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"linked": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"on_boot": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"plugged": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"mac_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"reported_devices": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"mac_address": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"description": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"comment": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ips": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"address": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"gateway": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"netmask": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"version": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceOvirtNicsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	vmID := d.Get("vm_id").(string)
+	nameRegex, nameRegexOK := d.GetOk("name_regex")
+
+	vmNicsServiceReq := conn.SystemService().VmsService().VmService(vmID).NicsService().List()
+
+	nicsResp, err := vmNicsServiceReq.Send()
+	if err != nil {
+		return err
+	}
+
+	nics, ok := nicsResp.Nics()
+	if !ok || len(nics.Slice()) == 0 {
+		return fmt.Errorf("your query returned no results, please change your search criteria and try again")
+	}
+
+	var filteredNics []*ovirtsdk4.Nic
+
+	if nameRegexOK {
+		r := regexp.MustCompile(nameRegex.(string))
+		for _, nic := range nics.Slice() {
+			if r.MatchString(nic.MustName()) {
+				filteredNics = append(filteredNics, nic)
+			}
+		}
+	} else {
+		filteredNics = nics.Slice()[:]
+	}
+
+	if len(filteredNics) == 0 {
+		return fmt.Errorf("your query returned no results, please change your search criteria and try again")
+	}
+
+	return nicsDecriptionAttributes(d, filteredNics, meta)
+}
+
+func nicsDecriptionAttributes(d *schema.ResourceData, nics []*ovirtsdk4.Nic, meta interface{}) error {
+	var s []map[string]interface{}
+	for _, v := range nics {
+		mapping := map[string]interface{}{
+			"id":        v.MustId(),
+			"name":      v.MustName(),
+			"interface": string(v.MustInterface()),
+			"plugged":   v.MustPlugged(),
+			"linked":    v.MustLinked(),
+		}
+
+		if bootProtocol, ok := v.BootProtocol(); ok {
+			mapping["boot_protocol"] = string(bootProtocol)
+		}
+		if comment, ok := v.Comment(); ok {
+			mapping["comment"] = comment
+		}
+		if desc, ok := v.Description(); ok {
+			mapping["description"] = desc
+		}
+		if onBoot, ok := v.OnBoot(); ok {
+			mapping["on_boot"] = onBoot
+		}
+		if mac, ok := v.Mac(); ok {
+			mapping["mac_address"] = mac.MustAddress()
+		}
+
+		if reportedDevices, ok := v.ReportedDevices(); ok && len(reportedDevices.Slice()) > 0 {
+			mapping["reported_devices"] = flattenOvirtNicReportedDevices(reportedDevices.Slice())
+		}
+
+		s = append(s, mapping)
+	}
+	d.SetId(resource.UniqueId())
+	return d.Set("nics", s)
+}
+
+func flattenOvirtNicReportedDevices(reportedDevices []*ovirtsdk4.ReportedDevice) []map[string]interface{} {
+	var s []map[string]interface{}
+
+	for _, v := range reportedDevices {
+		mapping := map[string]interface{}{
+			"id":   v.MustId(),
+			"name": v.MustName(),
+			"type": string(v.MustType()),
+		}
+
+		if desc, ok := v.Description(); ok {
+			mapping["description"] = desc
+		}
+		if comment, ok := v.Comment(); ok {
+			mapping["comment"] = comment
+		}
+
+		if mac, ok := v.Mac(); ok {
+			mapping["mac_address"] = mac.MustAddress()
+		}
+
+		if ips, ok := v.Ips(); ok && len(ips.Slice()) > 0 {
+			mapping["ips"] = flattenOvirtNicIps(ips.Slice())
+		}
+
+		s = append(s, mapping)
+	}
+
+	return s
+}
+
+func flattenOvirtNicIps(ips []*ovirtsdk4.Ip) []map[string]interface{} {
+	var s []map[string]interface{}
+
+	for _, v := range ips {
+		mapping := map[string]interface{}{}
+
+		if address, ok := v.Address(); ok {
+			mapping["address"] = address
+		}
+		if gateway, ok := v.Gateway(); ok {
+			mapping["gateway"] = gateway
+		}
+		if netmask, ok := v.Netmask(); ok {
+			mapping["netmask"] = netmask
+		}
+		if version, ok := v.Version(); ok {
+			mapping["version"] = version
+		}
+		s = append(s, mapping)
+	}
+
+	return s
+}

--- a/ovirt/data_source_ovirt_nics_test.go
+++ b/ovirt/data_source_ovirt_nics_test.go
@@ -1,0 +1,33 @@
+package ovirt
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccOvirtNicsDataSource_nameRegexFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOvirtNicsDataSourceNameRegexConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtDataSourceID("data.ovirt_nics.name_regex_filtered_nics"),
+					resource.TestCheckResourceAttr("data.ovirt_nics.name_regex_filtered_nics", "nics.#", "1"),
+					resource.TestMatchResourceAttr("data.ovirt_nics.name_regex_filtered_nics", "nics.0.name", regexp.MustCompile("^eth0*")),
+					resource.TestCheckResourceAttrSet("data.ovirt_nics.name_regex_filtered_nics", "nics.0.reported_devices.0.ips.0.address"),
+				),
+			},
+		},
+	})
+}
+
+var testAccCheckOvirtNicsDataSourceNameRegexConfig = `
+data "ovirt_nics" "name_regex_filtered_nics" {
+  name_regex = "^eth0*"
+  vm_id = "b9ea419c-7ce0-4508-8d04-8e75f60041ea"
+}
+`

--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -74,6 +74,7 @@ func Provider() terraform.ResourceProvider {
 			"ovirt_mac_pools":      dataSourceOvirtMacPools(),
 			"ovirt_vms":            dataSourceOvirtVMs(),
 			"ovirt_hosts":          dataSourceOvirtHosts(),
+			"ovirt_nics":           dataSourceOvirtNics(),
 		},
 	}
 }

--- a/website/docs/d/nics.html.markdown
+++ b/website/docs/d/nics.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "ovirt"
+page_title: "oVirt: ovirt_nics"
+sidebar_current: "docs-ovirt-datasource-nics"
+description: |-
+  Provides details about oVirt NICs
+---
+
+# Data Source: ovirt\_nics
+
+The oVirt NICs data source allows access to details of list of NICs of a VM within oVirt.
+
+## Example Usage
+
+```hcl
+data "ovirt_nics" "filtered_nics" {
+  name_regex = "^ovirtmgmt-t*"
+  vm_id      = "b9ea419c-7ce0-4508-8d04-8e75f60041ea"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name_regex` - (Optional) The fully functional regular expression for name
+* `vm_id` - (Required) The ID of the VM that the NIC belongs to
+
+> This data source dose not support for the regular oVirt query language.
+
+## Attributes Reference
+
+`nics` is set to the wrapper of the found NICs. Each item of `nic` contains the following attributes exported:
+
+* `id` - The ID of oVirt NIC
+* `name` - The name of oVirt NIC
+* `boot_protocol` - Defines how an IP address is assigned to the NIC
+* `comment` - Free text containing comments about the NIC
+* `description` - A human-readable description in plain text about the NIC
+* `interface` - The type of driver used for the NIC
+* `linked` - Defines if the NIC is linked to the VM
+* `on_boot` - Defines if the network interface should be activated upon operation system startup
+* `plugged` - Defines if the NIC is plugged in to the virtual machine
+* `mac_address` - The MAC address of the interface
+* `reported_devices` - A collection of reported devices that are associated with the virtual network interface
+  * `id` - The ID of the reported device
+  * `name` - The name of the reported device
+  * `mac_address` - The MAC address of the reported device
+  * `description` - A human-readable description in plain text about the reported device
+  * `comment` - Free text containing comments about the reported device
+  * `type` - The type of the reported device
+  * `ips` - A list of IP configurations of the reported device
+    * `address` - The text representation of the IP address
+    * `gateway` - The address of the default gateway
+    * `netmask` - The network mask
+    * `version` - The version of the IP protocol


### PR DESCRIPTION

Signed-off-by: imjoey <majunjiev@gmail.com>


Changes proposed in this pull request:

* Add support for new data source `ovirt_nics` to provide the details
about the NICs of a VM, or a Template (**not supported yet**)
* Add acceptance testing for this new data source
* Add relevant docs

Output from acceptance testing:

```
$ make testacc  TEST=./ovirt TESTARGS='-run=TestAccOvirtNicsDataSource_nameRegexFilter'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtNicsDataSource_nameRegexFilter -timeout 180m
=== RUN   TestAccOvirtNicsDataSource_nameRegexFilter
--- PASS: TestAccOvirtNicsDataSource_nameRegexFilter (0.55s)
PASS
ok      github.com/ovirt/terraform-provider-ovirt/ovirt 0.576s
```
