### PR TITLE
Add support for data source ovirt_template

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ provider "ovirt" {
   * ovirt_networks
   * ovirt_nics
   * ovirt_storagedomains
+  * ovirt_template
   * ovirt_users
   * ovirt_vms
   * ovirt_vnic_profiles

--- a/ovirt/data_source_ovirt_template.go
+++ b/ovirt/data_source_ovirt_template.go
@@ -1,0 +1,147 @@
+package ovirt
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+)
+
+func dataSourceOvirtTemplates() *schema.Resource {
+
+	return &schema.Resource{
+		Read: dataSourceOvirtTemplatesRead,
+		Schema: map[string]*schema.Schema{
+			"search": dataSourceSearchSchemaWith(
+				"max", "criteria", "case_sensitive"),
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.ValidateRegexp,
+			},
+
+			"templates": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cpu_shares": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"memory": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The memory of VM which associated with oVirt Template, in Megabytes(MB)",
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+}
+
+func dataSourceOvirtTemplatesRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*ovirtsdk4.Connection)
+
+	templatesReq := conn.SystemService().TemplatesService().List()
+
+	search, searchOK := d.GetOk("search")
+	nameRegex, nameRegexOK := d.GetOk("name_regex")
+
+	if searchOK {
+		searchMap := search.(map[string]interface{})
+		searchCriteria, searchCriteriaOK := searchMap["criteria"]
+		searchMax, searchMaxOK := searchMap["max"]
+		searchCaseSensitive, searchCaseSensitiveOK := searchMap["case_sensitive"]
+		if !searchCriteriaOK && !searchMaxOK && !searchCaseSensitiveOK {
+			return fmt.Errorf("One of criteria or max or case_sensitive in search must be assigned")
+		}
+
+		if searchCriteriaOK {
+			templatesReq.Search(searchCriteria.(string))
+		}
+		if searchMaxOK {
+			maxInt, err := strconv.ParseInt(searchMax.(string), 10, 64)
+			if err != nil || maxInt < 1 {
+				return fmt.Errorf("search.max must be a positive int")
+			}
+			templatesReq.Max(maxInt)
+		}
+		if searchCaseSensitiveOK {
+			csBool, err := strconv.ParseBool(searchCaseSensitive.(string))
+			if err != nil {
+				return fmt.Errorf("search.case_sensitive must be true or false")
+			}
+			templatesReq.CaseSensitive(csBool)
+		}
+	}
+	templatesResp, err := templatesReq.Send()
+	if err != nil {
+		return err
+	}
+	templates, ok := templatesResp.Templates()
+	if !ok || len(templates.Slice()) == 0 {
+		return fmt.Errorf("your query returned no results, please change your search criteria and try again")
+	}
+
+	var filteredTemplates []*ovirtsdk4.Template
+	if nameRegexOK {
+		r := regexp.MustCompile(nameRegex.(string))
+		for _, t := range templates.Slice() {
+			if r.MatchString(t.MustName()) {
+				filteredTemplates = append(filteredTemplates, t)
+			}
+		}
+	} else {
+		filteredTemplates = templates.Slice()[:]
+	}
+
+	if len(filteredTemplates) == 0 {
+		return fmt.Errorf("your query returned no results, please change your search criteria and try again")
+	}
+
+	return templatesDescriptionAttributes(d, filteredTemplates, meta)
+}
+
+func templatesDescriptionAttributes(d *schema.ResourceData, templates []*ovirtsdk4.Template, meta interface{}) error {
+	var s []map[string]interface{}
+
+	for _, v := range templates {
+		mapping := map[string]interface{}{
+			"id":            v.MustId(),
+			"name":          v.MustName(),
+			"cpu_shares":    v.MustCpuShares(),
+			"memory":        v.MustMemory() / int64(math.Pow(2, 20)),
+			"creation_time": v.MustCreationTime().Format(time.RFC3339),
+			"status":        v.MustStatus(),
+		}
+		s = append(s, mapping)
+	}
+	d.SetId(resource.UniqueId())
+	return d.Set("templates", s)
+}

--- a/ovirt/data_source_ovirt_template_test.go
+++ b/ovirt/data_source_ovirt_template_test.go
@@ -1,0 +1,60 @@
+package ovirt
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccOvirtTemplatesDataSource_nameRegexFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOvirtTemplatesDataSourceNameRegexConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtDataSourceID("data.ovirt_templates.name_regex_filtered_template"),
+					resource.TestCheckResourceAttr("data.ovirt_templates.name_regex_filtered_template", "templates.#", "2"),
+					resource.TestMatchResourceAttr("data.ovirt_templates.name_regex_filtered_template", "templates.0.name", regexp.MustCompile("^centOS*")),
+					resource.TestMatchResourceAttr("data.ovirt_templates.name_regex_filtered_template", "templates.1.name", regexp.MustCompile("^centOS*")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOvirtTemplatesDataSource_searchFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckOvirtTemplatesDataSourceSearchConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOvirtDataSourceID("data.ovirt_templates.search_filtered_template"),
+					resource.TestCheckResourceAttr("data.ovirt_templates.search_filtered_template", "templates.#", "1"),
+					resource.TestCheckResourceAttr("data.ovirt_templates.search_filtered_template", "templates.0.name", "centOST"),
+				),
+			},
+		},
+	})
+
+}
+
+var testAccCheckOvirtTemplatesDataSourceNameRegexConfig = `
+data "ovirt_templates" "name_regex_filtered_template" {
+  name_regex = "^centOS*"
+}
+`
+
+var testAccCheckOvirtTemplatesDataSourceSearchConfig = `
+data "ovirt_templates" "search_filtered_template" {
+  search = {
+    criteria       = "name = centOST"
+    max            = 2
+    case_sensitive = false
+  }
+}
+`

--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -75,6 +75,7 @@ func Provider() terraform.ResourceProvider {
 			"ovirt_vms":            dataSourceOvirtVMs(),
 			"ovirt_hosts":          dataSourceOvirtHosts(),
 			"ovirt_nics":           dataSourceOvirtNics(),
+			"ovirt_templates":      dataSourceOvirtTemplates(),
 		},
 	}
 }

--- a/website/docs/d/templates.html.markdown
+++ b/website/docs/d/templates.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "ovirt"
+page_title: "oVirt: ovirt_templates"
+sidebar_current: "docs-ovirt-datasource-templates"
+description: |-
+  Provides details about oVirt templates
+---
+
+# Data Source: ovirt\_templates
+
+The oVirt Templates data source allows access to details of list of templates within oVirt.
+
+## Example Usage
+
+```hcl
+data "ovirt_templates" "search_filtered_template" {
+  search = {
+    criteria       = "name = centOST"
+    max            = 2
+    case_sensitive = false
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name_regex` - (Optional) The fully functional regular expression for name
+* `search` - (Optional) The general search criteria representation, fitting the rules of [Searching](http://ovirt.github.io/ovirt-engine-api-model/master/#_searching)
+    * criteria - (Optional) The criteria for searching, using the same syntax as the oVirt query language
+    * max - (Optional) The maximum amount of objects returned. If not specified, the search will return all the objects.
+    * case_sensitive - (Optional) If the search are case sensitive, default value is `false`
+
+> The `search.criteria` also supports asterisk for searching by name, to indicate that any string matches, including the empty string. For example, the criteria `search=name=myobj*` will return all the objects with names beginning with `myobj`, such as `myobj2`, `myobj-test`. So, you could use `name_regex` for searching by complicated regular expression, and `search.criteria` for simple case accordingly.
+
+## Attributes Reference
+
+`templates` is set to the wrapper of the found templates. Each item of `templates` contains the following attributes exported:
+
+* `id` - The ID of oVirt Template
+* `name` - The name of oVirt Template
+* `cpu_shares` - The cpu shares of VM which associated with oVirt Template
+* `memory` - The memory of VM which associated with oVirt Template, in Megabytes(MB)
+* `creation_time` - The creation time of VM which associated with oVirt Template
+* `status` - The status of oVirt Template


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #182 

Changes proposed in this pull request:

* Add support for new data source `ovirt_template`
* Add acceptance testing for `ovirt_template`
* Add docs for `ovirt_template`

Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtTemplatesDataSource_*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtTemplatesDataSource_* -timeout 180m
=== RUN   TestAccOvirtTemplatesDataSource_nameRegexFilter
--- PASS: TestAccOvirtTemplatesDataSource_nameRegexFilter (0.73s)
=== RUN   TestAccOvirtTemplatesDataSource_searchFilter
--- PASS: TestAccOvirtTemplatesDataSource_searchFilter (0.58s)
PASS
ok      github.com/ovirt/terraform-provider-ovirt/ovirt 1.651s
```
