### PR TITLE
implement boot devices for vms

### DIFF
--- a/ovirt/resource_ovirt_vm.go
+++ b/ovirt/resource_ovirt_vm.go
@@ -546,8 +546,8 @@ func resourceOvirtVMRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func convertOS(os *ovirtsdk4.OperatingSystem) ([]map[string]interface{}, error) {
-	boot, _ := os.Boot()
-	devices, _ := boot.Devices()
+	boot := os.MustBoot()
+	devices := boot.MustDevices()
 	operatingSystems := make([]map[string]interface{}, 1)
 	operatingSystem := make(map[string]interface{})
 	operatingSystem["boot"] = make(map[string]interface{})

--- a/ovirt/resource_ovirt_vm.go
+++ b/ovirt/resource_ovirt_vm.go
@@ -118,6 +118,19 @@ func resourceOvirtVM() *schema.Resource {
 					},
 				},
 			},
+			"boot_devices": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(ovirtsdk4.BOOTDEVICE_CDROM),
+						string(ovirtsdk4.BOOTDEVICE_HD),
+						string(ovirtsdk4.BOOTDEVICE_NETWORK),
+					}, false),
+				},
+			},
 			"block_device": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -322,6 +335,27 @@ func resourceOvirtVMCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	vmBuilder.Cpu(cpu)
 
+	devices, err := expandOvirtBootDevices(d.Get("boot_devices").([]interface{}))
+	if err != nil {
+		return err
+	}
+
+	boot, err := ovirtsdk4.NewBootBuilder().
+		Devices(devices).
+		Build()
+	if err != nil {
+		return err
+	}
+
+	os, err := ovirtsdk4.NewOperatingSystemBuilder().
+		Boot(boot).
+		Build()
+	if err != nil {
+		return err
+	}
+
+	vmBuilder.Os(os)
+
 	if v, ok := d.GetOk("initialization"); ok {
 		initialization, err := expandOvirtVMInitialization(v.([]interface{}))
 		if err != nil {
@@ -479,6 +513,15 @@ func resourceOvirtVMRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("threads", vm.MustCpu().MustTopology().MustThreads())
 	d.Set("cluster_id", vm.MustCluster().MustId())
 
+	if len(d.Get("boot_devices").([]interface{})) != 0 {
+		os, err := convertOS(vm.MustOs())
+		if err != nil {
+			return fmt.Errorf("error setting operating system: %s", err)
+		}
+
+		d.Set("boot_devices", os[0]["boot"].(map[string]interface{})["devices"])
+	}
+
 	// If the virtual machine is cloned from a template or another virtual machine,
 	// the template links to the Blank template, and the original_template is used to track history.
 	// Otherwise the template and original_template are the same.
@@ -500,6 +543,20 @@ func resourceOvirtVMRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
+}
+
+func convertOS(os *ovirtsdk4.OperatingSystem) ([]map[string]interface{}, error) {
+	boot, _ := os.Boot()
+	devices, _ := boot.Devices()
+	operatingSystems := make([]map[string]interface{}, 1)
+	operatingSystem := make(map[string]interface{})
+	operatingSystem["boot"] = make(map[string]interface{})
+	outBoot := operatingSystem["boot"].(map[string]interface{})
+	outBoot["devices"] = devices
+
+	operatingSystems[0] = operatingSystem
+
+	return operatingSystems, nil
 }
 
 func resourceOvirtVMDelete(d *schema.ResourceData, meta interface{}) error {
@@ -643,6 +700,15 @@ func expandOvirtVMInitialization(l []interface{}) (*ovirtsdk4.Initialization, er
 		}
 	}
 	return initializationBuilder.Build()
+}
+
+func expandOvirtBootDevices(l []interface{}) ([]ovirtsdk4.BootDevice, error) {
+	devices := make([]ovirtsdk4.BootDevice, len(l))
+	for i, v := range l {
+		devices[i] = ovirtsdk4.BootDevice(v.(string))
+	}
+
+	return devices, nil
 }
 
 func expandOvirtVMNicConfigurations(l []interface{}) ([]*ovirtsdk4.NicConfiguration, error) {

--- a/website/docs/r/vm.html.markdown
+++ b/website/docs/r/vm.html.markdown
@@ -172,6 +172,7 @@ The following arguments are supported:
 * `sockets` - (Optional) The amount of sockets. Default is `1`. Changing this creates a new VM.
 * `threads` - (Optional) The amount of threads. Default is `1`. Changing this creates a new VM.
 * `block_device` - (Optional) Configurations of bootable disk block device. The block_device structure is documented below. Changing this creates a new VM. You can specify at most one block_device.
+* `boot_devices` - (Optional) The boot devices for the vm (the enum supports cdrom, hd, or network).
 * `initialization` - (Optional) Configurations of initialization. The initialization structure is documented below. Changint this updates the VM's initialization. You can specify at most one initialization.
 
 The `block_device` block supports:


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #189

Changes proposed in this pull request:

* add boot_devices to resource
* add populating boot_devices during reading resource
* implement mapping to ovirt API for boot devices

Output from acceptance testing:

```
make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtVM_noBootDevice'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtVM_noBootDevice -timeout 180m
=== RUN   TestAccOvirtVM_noBootDevice
--- PASS: TestAccOvirtVM_noBootDevice (142.48s)
PASS
ok      github.com/ovirt/terraform-provider-ovirt/ovirt 142.500s

make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtVM_bootDevice'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtVM_bootDevice -timeout 180m
=== RUN   TestAccOvirtVM_bootDevice
--- PASS: TestAccOvirtVM_bootDevice (161.50s)
PASS
ok      github.com/ovirt/terraform-provider-ovirt/ovirt 161.534s
...
```
