### PR TITLE
Fix immediate EOF on reads for image transfers via http(s)

### DIFF
--- a/ovirt/resource_ovirt_image_transfer.go
+++ b/ovirt/resource_ovirt_image_transfer.go
@@ -339,6 +339,13 @@ func PrepareForTransfer(sourceUrl string) (uploadSize int64, qcowSize uint64, so
 
 		sFile, err = ioutil.TempFile("/tmp", "*-ovirt-image.downloaded")
 		io.Copy(sFile, resp.Body)
+
+		// reset cursor to prep for reads
+		_, err = sFile.Seek(0, 0)
+		if err != nil {
+			return 0, 0, nil, "", err
+		}
+
 		// remove it when done or cache? maybe --cache
 		// defer os.Remove(sFile.Name())
 	}

--- a/ovirt/resource_ovirt_image_transfer.go
+++ b/ovirt/resource_ovirt_image_transfer.go
@@ -87,6 +87,9 @@ func resourceOvirtImageTransferCreate(d *schema.ResourceData, meta interface{}) 
 	sparse := d.Get("sparse").(bool)
 
 	uploadSize, qcowSize, sourceFile, format, err := PrepareForTransfer(sourceUrl)
+	if err != nil {
+		return fmt.Errorf("Failed preparing disk for transfer: %s", err)
+	}
 
 	diskBuilder := ovirtsdk4.NewDiskBuilder().
 		Alias(alias).


### PR DESCRIPTION
Fixes #187 

Changes proposed in this pull request:

* Resets file cursor after writing the temp image file for the next read.

Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtDataCenter_'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./ovirt -v -run=TestAccOvirtDataCenter_ -timeout 180m
=== RUN   TestAccOvirtDataCenter_basic
--- PASS: TestAccOvirtDataCenter_basic (1.51s)
PASS
ok      github.com/ovirt/terraform-provider-ovirt/ovirt 1.524s
...
```
