### PR TITLE
Override disk attachment on VM resource create

### DIFF
--- a/examples/vm/main.tf
+++ b/examples/vm/main.tf
@@ -33,14 +33,16 @@ resource "ovirt_vm" "my_vm_1" {
   # The `template_id` and `block_device` need to satisfy the following constraints:
   #   1. One of them must be assigned.
   #   2. If the template specified by `template_id` contains disks attached,
-  #      `block_device` can not be assigned.
+  #      `block_device` must be assigned without 'disk_id'. This will automatically
+  #       update the bootable disk of VM (the disk that copied from the template).
   #   3. If the template specified by `template_id` has no disks attached,
-  #      `block_device` must be assigned.
+  #      `block_device` must be assigned with 'disk_id'. This will attach a new disk.
 
   template_id = "${var.template_id}"
   block_device {
-    disk_id   = "${ovirt_disk.my_disk_1.id}"
+    disk_id   = "${ovirt_disk.my_disk_1.id}"  // optional
     interface = "virtio"
+    size      = 120   // size in GiB - in case disk_id is not passed, this would extend the disk.
   }
 }
 

--- a/ovirt/resource_ovirt_vm.go
+++ b/ovirt/resource_ovirt_vm.go
@@ -154,8 +154,14 @@ func resourceOvirtVM() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"disk_id": {
 							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Optional: true,
+							ForceNew: false,
+						},
+						"size": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    false,
+							Description: "in GiB",
 						},
 						"active": {
 							Type:     schema.TypeBool,
@@ -311,7 +317,11 @@ func resourceOvirtVMCreate(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 		if len(tds) > 0 && blockDeviceOk {
-			return fmt.Errorf("template_id with disks attached is conflict with block_device")
+			device := blockDevice.([]interface{})
+			// check if a disk id was passed to block_device, fail if so.
+			if diskID, _ := device[0].(map[string]interface{})["disk_id"].(string); diskID != "" {
+				return fmt.Errorf("template_id with disks attached is conflict with block_device")
+			}
 		}
 		if len(tds) == 0 && !blockDeviceOk {
 			return fmt.Errorf("template has no disks attached, so block_device must be assigned")
@@ -809,6 +819,10 @@ func expandOvirtVMDiskAttachment(d interface{}, disk *ovirtsdk4.Disk) (*ovirtsdk
 	builder.Bootable(true)
 	if disk != nil {
 		builder.Disk(disk)
+		if v, ok := dmap["size"]; ok {
+			newSize := int64(v.(int)) * int64(math.Pow(2, 30))
+			disk.SetProvisionedSize(newSize)
+		}
 	}
 	if v, ok := dmap["interface"]; ok {
 		builder.Interface(ovirtsdk4.DiskInterface(v.(string)))
@@ -860,9 +874,23 @@ func ovirtAttachDisks(s []interface{}, vmID string, meta interface{}) error {
 	conn := meta.(*ovirtsdk4.Connection)
 	vmService := conn.SystemService().VmsService().VmService(vmID)
 	for _, v := range s {
-		attachment := v.(map[string]interface{})
+		blockDeviceElement, ok := v.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("failed getting block_device content %v", blockDeviceElement)
+		}
+		// try the passed disk_id, if not, detect boot disk
+		diskID, ok := blockDeviceElement["disk_id"].(string)
+		attachmentExists := false
+		if !ok || diskID == "" {
+			findID, err := findVMBootDiskAttachmentID(vmService)
+			if err != nil {
+				return err
+			}
+			diskID = findID
+			attachmentExists = true
+		}
 		diskService := conn.SystemService().DisksService().
-			DiskService(attachment["disk_id"].(string))
+			DiskService(diskID)
 		var disk *ovirtsdk4.Disk
 		err := resource.Retry(30*time.Second, func() *resource.RetryError {
 			getDiskResp, err := diskService.Get().Send()
@@ -884,25 +912,59 @@ func ovirtAttachDisks(s []interface{}, vmID string, meta interface{}) error {
 			return err
 		}
 
-		err = resource.Retry(2*time.Minute, func() *resource.RetryError {
-			addAttachmentResp, err := vmService.DiskAttachmentsService().
-				Add().
-				Attachment(da).
-				Send()
-			if err != nil {
-				return resource.RetryableError(fmt.Errorf("failed to attach disk: %s, wait for next check", err))
-			}
-			_, ok := addAttachmentResp.Attachment()
-			if !ok {
-				return resource.RetryableError(fmt.Errorf("failed to attach disk: not exists in response, wait for next check"))
-			}
-			return nil
-		})
+		attachment, err := attachDisk(vmService.DiskAttachmentsService(), da, attachmentExists)
+		if err != nil {
+			return fmt.Errorf("failed to attach disk: %s", err)
+		}
+		err = conn.WaitForDisk(attachment.MustId(), ovirtsdk4.DISKSTATUS_OK, 20*time.Minute)
 		if err != nil {
 			return err
 		}
+		return nil
 	}
 	return nil
+}
+
+// attachDisk will attach a disk to vm or update an existing one. Returns the
+// new attachment or error.
+func attachDisk(service *ovirtsdk4.DiskAttachmentsService, attachment *ovirtsdk4.DiskAttachment, update bool) (*ovirtsdk4.DiskAttachment, error) {
+	if update {
+		r, err := service.
+			AttachmentService(attachment.MustDisk().MustId()).
+			Update().
+			DiskAttachment(attachment).
+			Send()
+		if err != nil {
+			return nil, err
+		}
+		return r.MustDiskAttachment(), nil
+	}
+	r, err := service.
+		Add().
+		Attachment(attachment).
+		Send()
+	if err != nil {
+		return nil, err
+	}
+	return r.MustAttachment(), nil
+}
+
+// findVMBootDiskAttachmentID returns the disk attachment id of
+// the bootable disk of a VM
+func findVMBootDiskAttachmentID(vmService *ovirtsdk4.VmService) (string, error) {
+	r, err := vmService.DiskAttachmentsService().List().Send()
+	if err != nil {
+		return "", err
+	}
+
+	for _, attachment := range r.MustAttachments().Slice() {
+		bootable, ok := attachment.Bootable()
+		if ok && bootable {
+			return attachment.MustId(), nil
+		}
+	}
+
+	return "", fmt.Errorf("no bootable disk for the VM")
 }
 
 func flattenOvirtVMDiskAttachments(configured []*ovirtsdk4.DiskAttachment) []map[string]interface{} {


### PR DESCRIPTION
Motivation
New VMs inherit their bootable disk attachement details from the template. A RHEL/RHCOS, CentOS, Ubuntu or any os would likely want to override those on creation. We want a bigger disk for some VMs, different driver, and do that in one-shot definition, without needing to go and create disk attachment resources and then terraform-refresh them.
    
Modification
The existing 'block_device' element in vm resource can take 'disk_id' optionally instead of mandatory. When the `disk_id` is lacking, the bootable disk that is attached to this newly created vm is updated with the details in `block_device`.

Result
We have a template with OS disk of 16Gib.
We want to create a new VM and extend the OS disk to 120Gib:
```hcl
resource "ovirt_vm" "masters" {
  ...
  template_id = xyz  // the template with 16GiB disk
  block_device {
      size = 120     // this will extend the disk to 120GiB
  }
}
```