### PR TITLE
Additions to VM resource

### DIFF
--- a/examples/vm/main.tf
+++ b/examples/vm/main.tf
@@ -8,7 +8,10 @@ resource "ovirt_vm" "my_vm_1" {
   name       = "my_vm_1"
   cluster_id = "${var.cluster_id}"
 
-  memory = 1024 # in MiB
+  # Instance type sets memory/cpu and more details of the VM.
+  instance_type_id = "0000000b-000b-000b-000b-00000000021f" // this is XLarge
+
+  memory = 1024 # in MiB - don't mix with instance_type_id
 
   initialization {
     authorized_ssh_key = "${file(pathexpand("~/.ssh/id_rsa.pub"))}"

--- a/website/docs/d/vms.html.markdown
+++ b/website/docs/d/vms.html.markdown
@@ -45,6 +45,7 @@ The following arguments are supported:
 * `cluster_id` - The ID of oVirt Cluster the VM belongs to
 * `status` - The current status of the VM
 * `template_id` - The ID of oVirt Template the VM creates from
+* `instance_type_id` - The ID of the Instance Type
 * `high_availability` - Defines if the HA is enabled
 * `memory` - The VM's memory, in Megabytes(MB)
 * `cores` - The CPU cores of the VM


### PR DESCRIPTION
 Add  instance_type support for ovirt_vm:

```
resource "ovirt_vm" "test" {
  ...
  instance_type_id = "<uuid of an instance type>"
}
```

To get a list of instance type of the system

`curl https://ovirt-engine-fqdn/ovirt-engine/api/instancetypes | jq '.[][]|.id,.name'`
