### PR TITLE
improve documentation

### DIFF
--- a/examples/cluster/main.tf
+++ b/examples/cluster/main.tf
@@ -23,6 +23,12 @@ data "ovirt_networks" "n" {
   }
 }
 
+data "ovirt_templates" "t" {
+  search = {
+    criteria       = ""
+    case_sensitive = false
+  }
+}
 
 locals {
   new_id        = [for t in data.ovirt_templates.t.templates : t.id if substr(t.name, 0, 5) != "Blank"]
@@ -42,6 +48,3 @@ output "networks" {
 output "cluster_networks" {
   value = local.cluster.0.networks
 }
-
-
-

--- a/website/docs/d/vnic_profiles.html.markdown
+++ b/website/docs/d/vnic_profiles.html.markdown
@@ -24,7 +24,7 @@ data "ovirt_vnic_profiles" "filtered_vnic_profiles" {
 The following arguments are supported:
 
 * `name_regex` - (Optional) The fully functional regular expression for name
-* `network_id` - (Optional) The ID of network the vnic profile belongs to
+* `network_id` - (Required) The ID of network the vnic profile belongs to
 
 > This data source dose not support for the regular oVirt query language.
 

--- a/website/docs/r/disk.html.markdown
+++ b/website/docs/r/disk.html.markdown
@@ -30,7 +30,7 @@ resource "ovirt_disk" "disk" {
 The following arguments are supported:
 
 * `name` - (Required) A unique name for the disk. Changing this updates the disk's name.
-* `alias` - (Optional) A alais for the disk. Changing this updates the disk's alias.
+* `alias` - (Optional) A alias for the disk. Changing this updates the disk's alias.
 * `format` - (Required) The format of the disk. Valid valus are `cow` and `raw`. Changing this creates a new disk.
 * `quota_id` - (Optional) The ID of quota applied to the disk. Changing this creates a new disk.
 * `storage_domain_id` - (Required) The ID of storage domain the disk residents. Changing this creates a new disk.

--- a/website/docs/r/vm.html.markdown
+++ b/website/docs/r/vm.html.markdown
@@ -179,7 +179,6 @@ The `block_device` block supports:
 
 * `disk_id` - (Required) The ID of attached disk. Changing this creates a new disk attachment.
 * `active` - (Optional) The flag to indicate whether the disk is active. Default is `true`. Changing this updates the attachment's active.
-* `bootable` - (Optional) The flag to indicate whether the disk is bootable. Default is `false`. Changing this updates the attachment's bootable.
 * `interface` - (Required) The interface of the attachment. Valid values are `ide`, `sata`, `spapr_vscsi`, `virtio` and `virtio_scsi`. Changing this creates a new attachment.
 * `pass_discard` - (Optional) The flag to indicate whether the VM passes discard commands to the storage. Changing this creates a new attachment.
 * `read_only` - (Optional) The flag to indicate whether the disk is connected to the VM as read only. Default is `false`. Changing this creates a new attachment.
@@ -198,7 +197,7 @@ The `initialization` block supports:
 
 The `nic_configuration` block supports:
 
-* `label` - (Required) Speficy the vNIC to apply this configuration.
+* `label` - (Required) Speficy the vNIC (e.g. eth0) to apply this configuration.
 * `boot_proto` - (Required) Set the boot protocol for the vNIC configuration. Valid values are `autoconf`, `dhcp`, `none` and `static`.
 * `address` - (Optional) Set the IP address for the vNIC.
 * `netmask` - (Optional) Set the netmask for the vNIC.


### PR DESCRIPTION
Changes proposed in this pull request:

* Change 1 - examples/cluster/main.tf
Add ovirt_templates data source so that the example works.  And remove unnecessary whitespace at the end of the file

* Change 2 - website/docs/d/vnic_profiles.html.markdown
Change network_id argument from Optional to Required

* Change 3 - website/docs/r/disk.html.markdown
Fix typo of "alias"

* Change 4 - website/docs/r/vm.html.markdown
Remove "bootable" arguement which doesn't exist.  And try to be more clear that "nic_configuration.label" refers to the in-guest name of the NIC