### PR TITLE
Disk Alias configuration during deploy VM from Template

### DIFF
--- a/examples/vm/main.tf
+++ b/examples/vm/main.tf
@@ -45,7 +45,8 @@ resource "ovirt_vm" "my_vm_1" {
   block_device {
     disk_id   = "${ovirt_disk.my_disk_1.id}"  // optional
     interface = "virtio"
-    size      = 120   // size in GiB - in case disk_id is not passed, this would extend the disk.
+    alias     = "my_vm_1" // optional. human friendly disk name on the disks list.
+    size      = 120   // optional. size in GiB - in case disk_id is not passed, this would extend the disk
   }
 }
 

--- a/ovirt/resource_ovirt_vm.go
+++ b/ovirt/resource_ovirt_vm.go
@@ -172,6 +172,11 @@ func resourceOvirtVM() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"alias": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: false,
+						},
 						"logical_name": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -955,8 +960,15 @@ func expandOvirtVMDiskAttachment(d interface{}, disk *ovirtsdk4.Disk) (*ovirtsdk
 	if disk != nil {
 		builder.Disk(disk)
 		if v, ok := dmap["size"]; ok {
-			newSize := int64(v.(int)) * int64(math.Pow(2, 30))
-			disk.SetProvisionedSize(newSize)
+			if v != 0 {
+				newSize := int64(v.(int)) * int64(math.Pow(2, 30))
+				disk.SetProvisionedSize(newSize)
+			}
+		}
+		if v, ok := dmap["alias"]; ok {
+			if v != "" {
+				disk.SetAlias(v.(string))
+			}
 		}
 	}
 	if v, ok := dmap["interface"]; ok {


### PR DESCRIPTION
Add possibility to setup Disk Alias during deploy VM from Template

Example:
```
resource "ovirt_vm" "vm_name" {
...
 
    block_device {
        interface      = "virtio_scsi"
        alias          = "vm_name_Disk1"
    }

    initialization {
        ...
}
```