### PR TITLE
Added option storage_domain parameter. Related only for build VM from…

### DIFF
--- a/examples/vm/main.tf
+++ b/examples/vm/main.tf
@@ -40,13 +40,18 @@ resource "ovirt_vm" "my_vm_1" {
   #       update the bootable disk of VM (the disk that copied from the template).
   #   3. If the template specified by `template_id` has no disks attached,
   #      `block_device` must be assigned with 'disk_id'. This will attach a new disk.
+  #   4. If will be configured alias and storage_domain terraform provider will define
+  #      alias for all disks, except bootable disk. Alias will be in format: vmname_Disk2,
+  #      vmname_Disk3
 
   template_id = "${var.template_id}"
   block_device {
     disk_id   = "${ovirt_disk.my_disk_1.id}"  // optional
     interface = "virtio"
-    alias     = "my_vm_1" // optional. human friendly disk name on the disks list.
-    size      = 120   // optional. size in GiB - in case disk_id is not passed, this would extend the disk
+    size      = 120   // size in GiB - in case disk_id is not passed, this would extend the disk.
+    alias          = "my_vm_1" // optional. human friendly disk name on the disks list.
+    storage_domain = "lun-5TB" // optional. define storage domain where will be created disks for VM.
+                               // Applied only for deploy VM from Template. disk_id shoud be removed.
   }
 }
 


### PR DESCRIPTION
Was added additionally option - **storage_domain**.
**storage_domain** - define destination storage domain to which will be copied disks during deploy VM from Template.

In production environment administrators usually have several storages.
Bu using storage_domain, administrator can specify to which storage will be deployed VM from Template. 

Usage example:
```
  block_device {
     disk_id   = "${ovirt_disk.my_disk_1.id}"  // optional
     interface = "virtio"
      ...
     storage_domain = "lun-5TB" // optional. define storage domain where will be created disks for VM. Applied only for deploy VM from Template. disk_id shoud be removed.
      ...
   }
```


Commit based on example from go_ovirt - https://github.com/oVirt/go-ovirt/blob/90013aa942c314a9bfa453c1907ba2ad4445bccf/examples/add_vm_from_template.go