### PR TITLE
WIP: Bug 1873022: Remove VM disk by default

### DIFF
--- a/ovirt/resource_ovirt_vm.go
+++ b/ovirt/resource_ovirt_vm.go
@@ -769,20 +769,9 @@ func resourceOvirtVMDelete(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	// VM created by Template must be remove with detachOnly=false
-	detachOnly := true
-	log.Printf("[DEBUG] Determine the detachOnly flag before removing VM (%s)", d.Id())
-	if vm.MustTemplate().MustId() != BlankTemplateID {
-		log.Printf("[DEBUG] Set detachOnly flag to false since VM (%s) is based on template (%s)",
-			d.Id(), vm.MustTemplate().MustId())
-		detachOnly = false
-	}
-
 	return resource.Retry(3*time.Minute, func() *resource.RetryError {
 		log.Printf("[DEBUG] Now to remove VM (%s)", d.Id())
-		_, err = vmService.Remove().
-			DetachOnly(detachOnly).
-			Send()
+		_, err = vmService.Remove().Send()
 		if err != nil {
 			if _, ok := err.(*ovirtsdk4.NotFoundError); ok {
 				// Wait until NotFoundError raises


### PR DESCRIPTION
When we try to remove a VM with terraform unless that VM was created from a template then the VM disk is not removed from the infrastructure.

This raises 2 problems:
1. It is inconsistent with the oVirt API, when you remove a VM with the oVirt API then unless a flag is specified then the VM disk will be removed.
2. Terraform should leave a clean infrastructure when removing resources, without any "extra" unmanaged resources.

This patch changes the behavior of ovirt vm removal, now when you remove a VM the underlying disk is also removed.

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>