### PR TITLE
Set detachOnly to false when deleting template clones

### DIFF
--- a/ovirt/resource_ovirt_vm.go
+++ b/ovirt/resource_ovirt_vm.go
@@ -781,8 +781,8 @@ func resourceOvirtVMDelete(d *schema.ResourceData, meta interface{}) error {
 	// VM created by Template must be remove with detachOnly=false
 	detachOnly := true
 	log.Printf("[DEBUG] Determine the detachOnly flag before removing VM (%s)", d.Id())
-	if vm.MustTemplate().MustId() != BlankTemplateID {
-		log.Printf("[DEBUG] Set detachOnly flag to false since VM (%s) is based on template (%s)",
+	if vm.MustTemplate().MustId() != BlankTemplateID || d.Get("clone").(bool) {
+		log.Printf("[DEBUG] Set detachOnly flag to false since VM (%s) is based on template (%s) or is a clone",
 			d.Id(), vm.MustTemplate().MustId())
 		detachOnly = false
 	}


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #223 

Changes proposed in this pull request:

* Delete disks attach to a VM we create by cloning a template. Otherwise these are left behind when the VM is deleted. This is in line with the current logic where we delete all disks attached to a VM if it was made from a template.

