### PR TITLE
Add auto_start flag to ovirt_vm resource

### DIFF
--- a/website/docs/d/vms.html.markdown
+++ b/website/docs/d/vms.html.markdown
@@ -42,6 +42,7 @@ The following arguments are supported:
 
 * `id` - The ID of oVirt VM
 * `name` - The name of oVirt VM
+* `auto_start` - If the VM should be started automatically on creation.
 * `cluster_id` - The ID of oVirt Cluster the VM belongs to
 * `status` - The current status of the VM
 * `template_id` - The ID of oVirt Template the VM creates from

--- a/website/docs/r/vm.html.markdown
+++ b/website/docs/r/vm.html.markdown
@@ -166,6 +166,7 @@ The following arguments are supported:
 
 * `name` - (Required) A unique name for the VM. Changing this creates a new VM.
 * `cluster_id` - (Required) The ID of cluster the VM belongs to. Changing this creates a new VM.
+* `auto_start` - (Optional) If the VM should be started automatically. Default is `true`. Changing this will cause the VM to stay in down state after creation.
 * `template_id` - (Optional) The ID of template the VM based on. Default is `00000000-0000-0000-0000-000000000000`. Changing this creates a new VM.
 * `memory` - (Optional) The amount of memory of the VM (in metabytes). Changing this creates a new VM.
 * `cores` - (Optional) The amount of cores. Default is `1`. Changing this creates a new VM.


### PR DESCRIPTION
The default behavior is that when we create a VM with the terraform provider the VM is automatically started.
We want the ability to create a VM and not start it.
Adding a flag to indicate if we want to start the VM on creation.

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>
