### PR TITLE
Added support for custom properties in templates and virtual machine …

### DIFF
--- a/ovirt/resource_ovirt_vm.go
+++ b/ovirt/resource_ovirt_vm.go
@@ -107,6 +107,22 @@ func resourceOvirtVM() *schema.Resource {
 					},
 				},
 			},
+			"custom_properties": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
 			"nics": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -452,6 +468,15 @@ func resourceOvirtVMCreate(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 	}
+	if cp, ok := d.GetOkExists("custom_properties"); ok {
+		customProperties, err := expandOvirtCustomProperties(cp.([]interface{}))
+		if err != nil {
+			return err
+		}
+		if len(customProperties) > 0 {
+			vmBuilder.CustomPropertiesOfAny(customProperties...)
+		}
+	}
 
 	os, err := expandOS(d)
 	if err != nil {
@@ -618,6 +643,16 @@ func resourceOvirtVMUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	vmBuilder.Cpu(cpu)
+
+	if cp, ok := d.GetOkExists("custom_properties"); ok {
+		customProperties, err := expandOvirtCustomProperties(cp.([]interface{}))
+		if err != nil {
+			return err
+		}
+		if len(customProperties) > 0 {
+			vmBuilder.CustomPropertiesOfAny(customProperties...)
+		}
+	}
 
 	//paramVM.Initialization(initialization)
 	if v, ok := d.GetOk("initialization"); ok {
@@ -984,6 +1019,23 @@ func expandOvirtBootDevices(l []interface{}) ([]ovirtsdk4.BootDevice, error) {
 	}
 
 	return devices, nil
+}
+
+func expandOvirtCustomProperties(l []interface{}) ([]*ovirtsdk4.CustomProperty, error) {
+	customProperties := make([]*ovirtsdk4.CustomProperty, len(l))
+	for i, v := range l {
+		vmap := v.(map[string]interface{})
+		customPropBuilder := ovirtsdk4.NewCustomPropertyBuilder()
+		customPropBuilder.Name(vmap["name"].(string))
+		customPropBuilder.Value(vmap["value"].(string))
+		customProp, err := customPropBuilder.Build()
+		if err != nil {
+			return nil, err
+		}
+
+		customProperties[i] = customProp
+	}
+	return customProperties, nil
 }
 
 func expandOvirtVMNicConfigurations(l []interface{}) ([]*ovirtsdk4.NicConfiguration, error) {

--- a/ovirt/resource_ovirt_vm_template.go
+++ b/ovirt/resource_ovirt_vm_template.go
@@ -101,6 +101,22 @@ func resourceOvirtTemplate() *schema.Resource {
 				Default:  1,
 				ForceNew: true,
 			},
+			"custom_properties": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
 			"nics": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -321,6 +337,16 @@ func resourceOvirtTemplateCreate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 	builder.Cpu(cpu)
+
+	if cp, ok := d.GetOkExists("custom_properties"); ok {
+		customProperties, err := expandOvirtCustomProperties(cp.([]interface{}))
+		if err != nil {
+			return err
+		}
+		if len(customProperties) > 0 {
+			builder.CustomPropertiesOfAny(customProperties...)
+		}
+	}
 
 	if v, ok := d.GetOk("initialization"); ok {
 		initialization, err := expandOvirtVMInitialization(v.([]interface{}))


### PR DESCRIPTION
Hello, I made a mini change to add custom_properties to ovirt_vm / ovirt_template schema.

I tested it against my ovirt installation (4.3.9), the VM is deployed with the appropriate custom property fields filled. 
However I'm not really aware about how the provider plugin work (as well as Terraform) so I may have missed some importants points in this change. 

So feel free to review this, and tell me how I can improve the code.

Have a nice day.