### PR TITLE
increase template and image transfer timeout

### DIFF
--- a/ovirt/resource_ovirt_image_transfer.go
+++ b/ovirt/resource_ovirt_image_transfer.go
@@ -38,7 +38,7 @@ func resourceOvirtImageTransfer() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Minute),
+			Create: schema.DefaultTimeout(20 * time.Minute),
 			Update: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},

--- a/ovirt/resource_ovirt_vm_template.go
+++ b/ovirt/resource_ovirt_vm_template.go
@@ -30,8 +30,8 @@ func resourceOvirtTemplate() *schema.Resource {
 		Delete: resourceOvirtTemplateDelete,
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Minute),
-			Update: schema.DefaultTimeout(10 * time.Minute),
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 


### PR DESCRIPTION
We noticed on OCP on RHV that sometimes we hit the timeout on the template creation or the image transfer.
This patch increases the timeout to 20m on create and update.

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>