### PR TITLE
Revert "increase template and image transfer timeout"

### DIFF
--- a/ovirt/resource_ovirt_image_transfer.go
+++ b/ovirt/resource_ovirt_image_transfer.go
@@ -38,7 +38,7 @@ func resourceOvirtImageTransfer() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
+			Create: schema.DefaultTimeout(10 * time.Minute),
 			Update: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},

--- a/ovirt/resource_ovirt_vm_template.go
+++ b/ovirt/resource_ovirt_vm_template.go
@@ -30,8 +30,8 @@ func resourceOvirtTemplate() *schema.Resource {
 		Delete: resourceOvirtTemplateDelete,
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
-			Update: schema.DefaultTimeout(20 * time.Minute),
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 


### PR DESCRIPTION
This reverts commit 17adf8398f24168619d28aadf4729d05c095c7b0.
 there is a way to override the default timeout from the resource definition
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtDataCenter_'

...
```
