### PR TITLE
Fix throwing a 404 error if we cannot find a disk by ID

### DIFF
--- a/ovirt/resource_ovirt_disk.go
+++ b/ovirt/resource_ovirt_disk.go
@@ -226,6 +226,11 @@ func resourceOvirtDiskRead(d *schema.ResourceData, meta interface{}) error {
 	getDiskResp, err := conn.SystemService().DisksService().
 		DiskService(d.Id()).Get().Send()
 	if err != nil {
+		_, ok := err.(*ovirtsdk4.NotFoundError)
+		if ok {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Don't throw a 404 Not Found error when trying to read a disk that doesn't exist.


Currently, if a disk is deleted outside of terraform but is still within TF state, the provider will throw a 404 error as is tries to read the disk by ID and fails.

This simply catches this and returns nil to result in the expected behaviour - TF tries to recreate the disk.

