### PR TITLE
preparing for v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,63 @@
+## [v0.5.0](https://github.com/oVirt/terraform-provider-ovirt/tree/v0.5.0) (2021-01-07)
+
+[Full Changelog](https://github.com/oVirt/terraform-provider-ovirt/compare/v0.4.2...v0.5.0)
+
+**Implemented enhancements:**
+
+- Request for New Data Source: ovirt\_template  [\#182](https://github.com/oVirt/terraform-provider-ovirt/issues/182)
+- Get IP address of the new VM [\#172](https://github.com/oVirt/terraform-provider-ovirt/issues/172)
+- Feature request: support for sysprep to initialize windows VMs [\#158](https://github.com/oVirt/terraform-provider-ovirt/issues/158)
+- Drop vendor dir [\#148](https://github.com/oVirt/terraform-provider-ovirt/issues/148)
+- Request for New Resource: ovirt\_domain [\#94](https://github.com/oVirt/terraform-provider-ovirt/issues/94)
+
+**Fixed bugs:**
+
+- Update for libgo.so.11-\>libgo.so.13? [\#125](https://github.com/oVirt/terraform-provider-ovirt/issues/125)
+
+**Closed issues:**
+
+- VM resource delete leaving disks [\#223](https://github.com/oVirt/terraform-provider-ovirt/issues/223)
+- Could not locate Gemfile during `make website` [\#211](https://github.com/oVirt/terraform-provider-ovirt/issues/211)
+- Cannot use ovirt\_image\_transfer with FCOS image [\#197](https://github.com/oVirt/terraform-provider-ovirt/issues/197)
+- Support OS property on VM [\#191](https://github.com/oVirt/terraform-provider-ovirt/issues/191)
+- vm boot devices [\#189](https://github.com/oVirt/terraform-provider-ovirt/issues/189)
+- ovirt\_image\_transfer: The string '' isnt a valid value for the DiskFormat  [\#187](https://github.com/oVirt/terraform-provider-ovirt/issues/187)
+- RESTEASY002010: Failed to execute: javax.ws.rs.WebApplicationException: HTTP 404 Not Found [\#180](https://github.com/oVirt/terraform-provider-ovirt/issues/180)
+- Unable to set network on RHEV VM [\#179](https://github.com/oVirt/terraform-provider-ovirt/issues/179)
+
+**Merged pull requests:**
+
+- WIP: Add priority to affinity group resource [\#240](https://github.com/oVirt/terraform-provider-ovirt/pull/240) ([Gal-Zaidman](https://github.com/Gal-Zaidman))
+- Fix throwing a 404 error if we cannot find a disk by ID [\#238](https://github.com/oVirt/terraform-provider-ovirt/pull/238) ([jake2184](https://github.com/jake2184))
+- Add 'latest' as a flag to data\_source\_template [\#237](https://github.com/oVirt/terraform-provider-ovirt/pull/237) ([jake2184](https://github.com/jake2184))
+- Revert "increase template and image transfer timeout" [\#234](https://github.com/oVirt/terraform-provider-ovirt/pull/234) ([emesika](https://github.com/emesika))
+- increase template and image transfer timeout [\#233](https://github.com/oVirt/terraform-provider-ovirt/pull/233) ([Gal-Zaidman](https://github.com/Gal-Zaidman))
+- moving docs into the new location the registry prefers [\#232](https://github.com/oVirt/terraform-provider-ovirt/pull/232) ([attachmentgenie](https://github.com/attachmentgenie))
+- import of release workflow from provider scafolding [\#231](https://github.com/oVirt/terraform-provider-ovirt/pull/231) ([attachmentgenie](https://github.com/attachmentgenie))
+- Add auto\_start flag to ovirt\_vm resource [\#227](https://github.com/oVirt/terraform-provider-ovirt/pull/227) ([Gal-Zaidman](https://github.com/Gal-Zaidman))
+- Add Affinity Group resource [\#225](https://github.com/oVirt/terraform-provider-ovirt/pull/225) ([jake2184](https://github.com/jake2184))
+- Set detachOnly to false when deleting template clones [\#224](https://github.com/oVirt/terraform-provider-ovirt/pull/224) ([jake2184](https://github.com/jake2184))
+- Added static hardware address configuration for vm nics [\#221](https://github.com/oVirt/terraform-provider-ovirt/pull/221) ([s-all-kin](https://github.com/s-all-kin))
+- Allow OS to be updated rather than recreating VM [\#219](https://github.com/oVirt/terraform-provider-ovirt/pull/219) ([jake2184](https://github.com/jake2184))
+- Added option storage\_domain parameter. Related only for build VM from… [\#216](https://github.com/oVirt/terraform-provider-ovirt/pull/216) ([pavel-z1](https://github.com/pavel-z1))
+- Disk Alias configuration during deploy VM from Template [\#214](https://github.com/oVirt/terraform-provider-ovirt/pull/214) ([pavel-z1](https://github.com/pavel-z1))
+- image\_transfer: failed OPTIONS request will panic [\#206](https://github.com/oVirt/terraform-provider-ovirt/pull/206) ([rgolangh](https://github.com/rgolangh))
+- Handle empty instance type Creating a Vm with empty instance type is allowed, and the resource read need to handle a case where its missing. [\#203](https://github.com/oVirt/terraform-provider-ovirt/pull/203) ([rgolangh](https://github.com/rgolangh))
+- Additions to VM resource [\#202](https://github.com/oVirt/terraform-provider-ovirt/pull/202) ([rgolangh](https://github.com/rgolangh))
+- Override disk attachment on VM resource create [\#201](https://github.com/oVirt/terraform-provider-ovirt/pull/201) ([rgolangh](https://github.com/rgolangh))
+- Initialization additions to VM [\#200](https://github.com/oVirt/terraform-provider-ovirt/pull/200) ([rgolangh](https://github.com/rgolangh))
+- Update VM parameters feature and VM running Status [\#198](https://github.com/oVirt/terraform-provider-ovirt/pull/198) ([pavel-z1](https://github.com/pavel-z1))
+- Fix immediate EOF on reads for image transfers via http\(s\) [\#195](https://github.com/oVirt/terraform-provider-ovirt/pull/195) ([r0ci](https://github.com/r0ci))
+- implement boot devices for vms [\#194](https://github.com/oVirt/terraform-provider-ovirt/pull/194) ([mathianasj](https://github.com/mathianasj))
+- Update go-ovirt dependency to v4.4.1 [\#190](https://github.com/oVirt/terraform-provider-ovirt/pull/190) ([imjoey](https://github.com/imjoey))
+- Migrate to terraform-plugin-sdk [\#188](https://github.com/oVirt/terraform-provider-ovirt/pull/188) ([LorbusChris](https://github.com/LorbusChris))
+- Update main.tf [\#185](https://github.com/oVirt/terraform-provider-ovirt/pull/185) ([Oddly](https://github.com/Oddly))
+- Add Image Transfer resources [\#184](https://github.com/oVirt/terraform-provider-ovirt/pull/184) ([rgolangh](https://github.com/rgolangh))
+- Add support for data source ovirt\_template [\#183](https://github.com/oVirt/terraform-provider-ovirt/pull/183) ([imjoey](https://github.com/imjoey))
+- doc: Improve the expressions [\#181](https://github.com/oVirt/terraform-provider-ovirt/pull/181) ([imjoey](https://github.com/imjoey))
+- docs: Update to using go version 1.12+ [\#178](https://github.com/oVirt/terraform-provider-ovirt/pull/178) ([imjoey](https://github.com/imjoey))
+- Replaces apache thrift module source [\#177](https://github.com/oVirt/terraform-provider-ovirt/pull/177) ([beremtl](https://github.com/beremtl))
+
 ## 0.4.2 (Sep 10, 2019)
 
 FEATURES:
@@ -8,7 +68,6 @@ IMPROVEMENTS:
 
 * resource/ovirt_datacenter: Make the status field exportable ([#170](https://github.com/oVirt/terraform-provider-ovirt/pull/170))
 * data/ovirt_vms: Export IP configurations of VM ([#174](https://github.com/oVirt/terraform-provider-ovirt/pull/174))
-
 
 ## 0.4.1 (Jul 31, 2019)
 
@@ -27,7 +86,6 @@ IMPROVEMENTS:
 * provider: Add more general method for parsing composite resource ID ([#163](https://github.com/oVirt/terraform-provider-ovirt/pull/163))
 * provider: Format the HCL codes definied in acceptance tests ([#160](https://github.com/oVirt/terraform-provider-ovirt/pull/160))
 
-
 ## 0.4.0 (Jul 8, 2019)
 
 BACKWARDS INCOMPATIBILITIES / NOTES:
@@ -39,7 +97,6 @@ IMPROVEMENTS:
 * provider: Update to Terraform v0.12.2 ([#145](https://github.com/oVirt/terraform-provider-ovirt/pull/145))
 * provider: Remove serveral unnecessary scripts in CI process ([#153](https://github.com/oVirt/terraform-provider-ovirt/pull/153))
 * provider: Set `GOFLAGS` in CI environment to force `go mod` to use packages under vendor directory ([#155](https://github.com/oVirt/terraform-provider-ovirt/pull/155))
-
 
 ## 0.3.1 (Jun 10, 2019)
 
@@ -55,20 +112,17 @@ IMPROVEMENTS:
 
 * provider: Update to Terraform v0.12.1 ([#141](https://github.com/imjoey/terraform-provider-ovirt/pull/141))
 
-
 ## 0.3.0 (May 29, 2019)
 
 BACKWARDS INCOMPATIBILITIES / NOTES:
 
 * provider: This release contains only a Terraform SDK upgrade for compatibility with Terraform v0.12. The provider should remains backwards compatible with Terraform v0.11. This update should have no significant changes in behavior for the provider. Please report any unexpected behavior in new GitHub issues (Terraform oVirt Provider: https://github.com/imjoey/terraform-provider-ovirt/issues) ([#133](https://github.com/imjoey/terraform-provider-ovirt/pull/133))
 
-
 ## 0.2.2 (May 27, 2019)
 
 BUG FIXES:
 
 * resource/ovirt_vm: Prevent creating VM failure and mistaken state diffs due to `memory` attribute
-
 
 ## 0.2.1 (May 22, 2019)
 
@@ -85,7 +139,6 @@ FEATURES:
 * **New Data Source:** `ovirt_mac_pools` ([#109](https://github.com/imjoey/terraform-provider-ovirt/pull/109))
 * **New Data Source:** `ovirt_vms` ([#118](https://github.com/imjoey/terraform-provider-ovirt/pull/118))
 
-
 IMPROVEMENTS:
 
 * provider: Add `header` params support for connection settings ([#72](https://github.com/imjoey/terraform-provider-ovirt/pull/72))
@@ -95,13 +148,11 @@ IMPROVEMENTS:
 * resource/ovirt_network: Add acceptance tests ([#91](https://github.com/imjoey/terraform-provider-ovirt/pull/91))
 * resource/ovirt_vm: Add `clone` support ([#131](https://github.com/imjoey/terraform-provider-ovirt/pull/131))
 
-
 ## 0.2.0 (September 26, 2018)
 
 BACKWARDS INCOMPATIBILITIES / NOTES:
 
 * provider: All the new or existing resources and data sources have been refactored with the [oVirt Go SDK](https://github.com/imjoey/go-ovirt) to access the oVirt engine API
-
 
 FEATURES:
 
@@ -124,17 +175,14 @@ IMPROVEMENTS:
 * provider: Add travis CI support ([#47](https://github.com/imjoey/terraform-provider-ovirt/pull/47))
 * provider: Add missing attributes and processing logic for the existing `ovirt_vm`, `ovirt_disk` resources and `ovirt_disk` data source defined in v0.1.0
 
-
 ## 0.1.0 (March 13, 2018)
 
 BACKWARDS INCOMPATIBILITIES / NOTES:
 
 * Release by [EMSL-MSC](https://github.com/EMSL-MSC/terraform-provider-ovirt/commits) Orgnization, please see [here](https://github.com/EMSL-MSC/terraform-provider-ovirt/releases/tag/0.1.0) for details.
 
-
 FEATURES:
 
 * **New Resource:** `ovirt_vm`
 * **New Resource:** `ovirt_disk`
 * **New Data Source:** `ovirt_disk`
-


### PR DESCRIPTION
Generated a changelog for the newly to be released version. I selected 0.5.0 at random but am happy to adjust. the changelog was generated using github-changelog-generator/github-changelog-generator which uses tags to categorize pr's and ticket into categories.
