### PR TITLE
Fixes #244: root_password visible in terraform plan

### DIFF
--- a/ovirt/resource_ovirt_host.go
+++ b/ovirt/resource_ovirt_host.go
@@ -55,6 +55,7 @@ func resourceOvirtHost() *schema.Resource {
 				Required:     true,
 				ForceNew:     false,
 				ValidateFunc: validation.NoZeroValues,
+				Sensitive:    true,
 			},
 			"cluster_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #244

Changes proposed in this pull request:

* Fixes issue: #244 root_password visible in terraform plan

Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtDataCenter_'

...
```
