### PR TITLE
introduce auto pinning policy

### DIFF
--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -167,6 +167,7 @@ The following arguments are supported:
 * `block_device` - (Optional) Configurations of bootable disk block device. The block_device structure is documented below. Changing this creates a new VM. You can specify at most one block_device.
 * `boot_devices` - (Optional) The boot devices for the vm (the enum supports cdrom, hd, or network).
 * `initialization` - (Optional) Configurations of initialization. The initialization structure is documented below. Changint this updates the VM's initialization. You can specify at most one initialization.
+* `auto_pinning_policy` - (Optional) The policy for automatically pinning the CPUs and NUMAs of the VM. High Performance VMs default is `existing`.
 
 The `block_device` block supports:
 

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/hashicorp/hcl/v2 v2.3.0 // indirect
 	github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.8.0
-	github.com/ovirt/go-ovirt v0.0.0-20210112072624-e4d3b104de71
+	github.com/ovirt/go-ovirt v0.0.0-20210308100159-ac0bcbc88d7c
 )

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY7
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/ovirt/go-ovirt v0.0.0-20210112072624-e4d3b104de71 h1:rMPlu5YNQomOQ9hXQDcYTfcmFy8rlYgeDJPPl1qgqz8=
-github.com/ovirt/go-ovirt v0.0.0-20210112072624-e4d3b104de71/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
+github.com/ovirt/go-ovirt v0.0.0-20210308100159-ac0bcbc88d7c h1:2SbYZedeIawU8sGFnohfrdEcEMBA4V8SDouG6hly+H4=
+github.com/ovirt/go-ovirt v0.0.0-20210308100159-ac0bcbc88d7c/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/vendor/github.com/ovirt/go-ovirt/CHANGES.adoc
+++ b/vendor/github.com/ovirt/go-ovirt/CHANGES.adoc
@@ -2,6 +2,14 @@
 
 This document describes the relevant changes between releases of the SDK.
 
+== 4.4.4 / Mar 04 2021
+
+Update to model 4.4.25
+
+Bug Fixes:
+
+* None
+
 == 4.4.3 / Jan 11 2021
 
 Update to model 4.4.22 and metamodel 1.3.4

--- a/vendor/github.com/ovirt/go-ovirt/services.go
+++ b/vendor/github.com/ovirt/go-ovirt/services.go
@@ -34332,6 +34332,7 @@ type HostServiceApproveRequest struct {
 	async       *bool
 	cluster     *Cluster
 	host        *Host
+	reboot      *bool
 }
 
 func (p *HostServiceApproveRequest) Header(key, value string) *HostServiceApproveRequest {
@@ -34370,6 +34371,11 @@ func (p *HostServiceApproveRequest) Host(host *Host) *HostServiceApproveRequest 
 	return p
 }
 
+func (p *HostServiceApproveRequest) Reboot(reboot bool) *HostServiceApproveRequest {
+	p.reboot = &reboot
+	return p
+}
+
 func (p *HostServiceApproveRequest) Send() (*HostServiceApproveResponse, error) {
 	rawURL := fmt.Sprintf("%s%s/approve", p.HostService.connection.URL(), p.HostService.path)
 	actionBuilder := NewActionBuilder()
@@ -34381,6 +34387,9 @@ func (p *HostServiceApproveRequest) Send() (*HostServiceApproveResponse, error) 
 	}
 	actionBuilder.Cluster(p.cluster)
 	actionBuilder.Host(p.host)
+	if p.reboot != nil {
+		actionBuilder.Reboot(*p.reboot)
+	}
 	action, err := actionBuilder.Build()
 	if err != nil {
 		return nil, err
@@ -35697,6 +35706,7 @@ type HostServiceInstallRequest struct {
 	deployHostedEngine   *bool
 	host                 *Host
 	image                *string
+	reboot               *bool
 	rootPassword         *string
 	ssh                  *Ssh
 	undeployHostedEngine *bool
@@ -35743,6 +35753,11 @@ func (p *HostServiceInstallRequest) Image(image string) *HostServiceInstallReque
 	return p
 }
 
+func (p *HostServiceInstallRequest) Reboot(reboot bool) *HostServiceInstallRequest {
+	p.reboot = &reboot
+	return p
+}
+
 func (p *HostServiceInstallRequest) RootPassword(rootPassword string) *HostServiceInstallRequest {
 	p.rootPassword = &rootPassword
 	return p
@@ -35773,6 +35788,9 @@ func (p *HostServiceInstallRequest) Send() (*HostServiceInstallResponse, error) 
 	actionBuilder.Host(p.host)
 	if p.image != nil {
 		actionBuilder.Image(*p.image)
+	}
+	if p.reboot != nil {
+		actionBuilder.Reboot(*p.reboot)
 	}
 	if p.rootPassword != nil {
 		actionBuilder.RootPassword(*p.rootPassword)
@@ -36678,8 +36696,8 @@ func (p *HostService) Remove() *HostServiceRemoveRequest {
 //         <name>bond0</name>
 //       </host_nic>
 //       <ip_address_assignments>
-//         <assignment_method>static</assignment_method>
 //         <ip_address_assignment>
+//           <assignment_method>static</assignment_method>
 //           <ip>
 //             <address>192.168.122.10</address>
 //             <netmask>255.255.255.0</netmask>
@@ -37076,8 +37094,8 @@ func (p *HostServiceSetupNetworksRequest) MustSend() *HostServiceSetupNetworksRe
 //         <name>bond0</name>
 //       </host_nic>
 //       <ip_address_assignments>
-//         <assignment_method>static</assignment_method>
 //         <ip_address_assignment>
+//           <assignment_method>static</assignment_method>
 //           <ip>
 //             <address>192.168.122.10</address>
 //             <netmask>255.255.255.0</netmask>
@@ -37237,8 +37255,8 @@ type HostServiceSetupNetworksResponse struct {
 //         <name>bond0</name>
 //       </host_nic>
 //       <ip_address_assignments>
-//         <assignment_method>static</assignment_method>
 //         <ip_address_assignment>
+//           <assignment_method>static</assignment_method>
 //           <ip>
 //             <address>192.168.122.10</address>
 //             <netmask>255.255.255.0</netmask>
@@ -38124,6 +38142,7 @@ type HostServiceApproveUsingRootPasswordRequest struct {
 	async       *bool
 	cluster     *Cluster
 	host        *Host
+	reboot      *bool
 }
 
 func (p *HostServiceApproveUsingRootPasswordRequest) Header(key, value string) *HostServiceApproveUsingRootPasswordRequest {
@@ -38162,6 +38181,11 @@ func (p *HostServiceApproveUsingRootPasswordRequest) Host(host *Host) *HostServi
 	return p
 }
 
+func (p *HostServiceApproveUsingRootPasswordRequest) Reboot(reboot bool) *HostServiceApproveUsingRootPasswordRequest {
+	p.reboot = &reboot
+	return p
+}
+
 func (p *HostServiceApproveUsingRootPasswordRequest) Send() (*HostServiceApproveUsingRootPasswordResponse, error) {
 	rawURL := fmt.Sprintf("%s%s/usingrootpassword", p.HostService.connection.URL(), p.HostService.path)
 	actionBuilder := NewActionBuilder()
@@ -38173,6 +38197,9 @@ func (p *HostServiceApproveUsingRootPasswordRequest) Send() (*HostServiceApprove
 	}
 	actionBuilder.Cluster(p.cluster)
 	actionBuilder.Host(p.host)
+	if p.reboot != nil {
+		actionBuilder.Reboot(*p.reboot)
+	}
 	action, err := actionBuilder.Build()
 	if err != nil {
 		return nil, err
@@ -38271,6 +38298,7 @@ type HostServiceInstallUsingRootPasswordRequest struct {
 	deployHostedEngine   *bool
 	host                 *Host
 	image                *string
+	reboot               *bool
 	rootPassword         *string
 	ssh                  *Ssh
 	undeployHostedEngine *bool
@@ -38317,6 +38345,11 @@ func (p *HostServiceInstallUsingRootPasswordRequest) Image(image string) *HostSe
 	return p
 }
 
+func (p *HostServiceInstallUsingRootPasswordRequest) Reboot(reboot bool) *HostServiceInstallUsingRootPasswordRequest {
+	p.reboot = &reboot
+	return p
+}
+
 func (p *HostServiceInstallUsingRootPasswordRequest) RootPassword(rootPassword string) *HostServiceInstallUsingRootPasswordRequest {
 	p.rootPassword = &rootPassword
 	return p
@@ -38347,6 +38380,9 @@ func (p *HostServiceInstallUsingRootPasswordRequest) Send() (*HostServiceInstall
 	actionBuilder.Host(p.host)
 	if p.image != nil {
 		actionBuilder.Image(*p.image)
+	}
+	if p.reboot != nil {
+		actionBuilder.Reboot(*p.reboot)
 	}
 	if p.rootPassword != nil {
 		actionBuilder.RootPassword(*p.rootPassword)
@@ -38603,6 +38639,7 @@ type HostServiceApproveUsingSshRequest struct {
 	async       *bool
 	cluster     *Cluster
 	host        *Host
+	reboot      *bool
 }
 
 func (p *HostServiceApproveUsingSshRequest) Header(key, value string) *HostServiceApproveUsingSshRequest {
@@ -38641,6 +38678,11 @@ func (p *HostServiceApproveUsingSshRequest) Host(host *Host) *HostServiceApprove
 	return p
 }
 
+func (p *HostServiceApproveUsingSshRequest) Reboot(reboot bool) *HostServiceApproveUsingSshRequest {
+	p.reboot = &reboot
+	return p
+}
+
 func (p *HostServiceApproveUsingSshRequest) Send() (*HostServiceApproveUsingSshResponse, error) {
 	rawURL := fmt.Sprintf("%s%s/usingssh", p.HostService.connection.URL(), p.HostService.path)
 	actionBuilder := NewActionBuilder()
@@ -38652,6 +38694,9 @@ func (p *HostServiceApproveUsingSshRequest) Send() (*HostServiceApproveUsingSshR
 	}
 	actionBuilder.Cluster(p.cluster)
 	actionBuilder.Host(p.host)
+	if p.reboot != nil {
+		actionBuilder.Reboot(*p.reboot)
+	}
 	action, err := actionBuilder.Build()
 	if err != nil {
 		return nil, err
@@ -38754,6 +38799,7 @@ type HostServiceInstallUsingSshRequest struct {
 	deployHostedEngine   *bool
 	host                 *Host
 	image                *string
+	reboot               *bool
 	rootPassword         *string
 	ssh                  *Ssh
 	undeployHostedEngine *bool
@@ -38800,6 +38846,11 @@ func (p *HostServiceInstallUsingSshRequest) Image(image string) *HostServiceInst
 	return p
 }
 
+func (p *HostServiceInstallUsingSshRequest) Reboot(reboot bool) *HostServiceInstallUsingSshRequest {
+	p.reboot = &reboot
+	return p
+}
+
 func (p *HostServiceInstallUsingSshRequest) RootPassword(rootPassword string) *HostServiceInstallUsingSshRequest {
 	p.rootPassword = &rootPassword
 	return p
@@ -38830,6 +38881,9 @@ func (p *HostServiceInstallUsingSshRequest) Send() (*HostServiceInstallUsingSshR
 	actionBuilder.Host(p.host)
 	if p.image != nil {
 		actionBuilder.Image(*p.image)
+	}
+	if p.reboot != nil {
+		actionBuilder.Reboot(*p.reboot)
 	}
 	if p.rootPassword != nil {
 		actionBuilder.RootPassword(*p.rootPassword)
@@ -39592,6 +39646,7 @@ type HostsServiceAddRequest struct {
 	activate             *bool
 	deployHostedEngine   *bool
 	host                 *Host
+	reboot               *bool
 	undeployHostedEngine *bool
 }
 
@@ -39626,6 +39681,11 @@ func (p *HostsServiceAddRequest) Host(host *Host) *HostsServiceAddRequest {
 	return p
 }
 
+func (p *HostsServiceAddRequest) Reboot(reboot bool) *HostsServiceAddRequest {
+	p.reboot = &reboot
+	return p
+}
+
 func (p *HostsServiceAddRequest) UndeployHostedEngine(undeployHostedEngine bool) *HostsServiceAddRequest {
 	p.undeployHostedEngine = &undeployHostedEngine
 	return p
@@ -39640,6 +39700,10 @@ func (p *HostsServiceAddRequest) Send() (*HostsServiceAddResponse, error) {
 
 	if p.deployHostedEngine != nil {
 		values["deploy_hosted_engine"] = []string{fmt.Sprintf("%v", *p.deployHostedEngine)}
+	}
+
+	if p.reboot != nil {
+		values["reboot"] = []string{fmt.Sprintf("%v", *p.reboot)}
 	}
 
 	if p.undeployHostedEngine != nil {
@@ -40128,6 +40192,7 @@ type HostsServiceAddUsingRootPasswordRequest struct {
 	activate             *bool
 	deployHostedEngine   *bool
 	host                 *Host
+	reboot               *bool
 	undeployHostedEngine *bool
 }
 
@@ -40162,6 +40227,11 @@ func (p *HostsServiceAddUsingRootPasswordRequest) Host(host *Host) *HostsService
 	return p
 }
 
+func (p *HostsServiceAddUsingRootPasswordRequest) Reboot(reboot bool) *HostsServiceAddUsingRootPasswordRequest {
+	p.reboot = &reboot
+	return p
+}
+
 func (p *HostsServiceAddUsingRootPasswordRequest) UndeployHostedEngine(undeployHostedEngine bool) *HostsServiceAddUsingRootPasswordRequest {
 	p.undeployHostedEngine = &undeployHostedEngine
 	return p
@@ -40177,6 +40247,9 @@ func (p *HostsServiceAddUsingRootPasswordRequest) Send() (*HostsServiceAddUsingR
 		actionBuilder.DeployHostedEngine(*p.deployHostedEngine)
 	}
 	actionBuilder.Host(p.host)
+	if p.reboot != nil {
+		actionBuilder.Reboot(*p.reboot)
+	}
 	if p.undeployHostedEngine != nil {
 		actionBuilder.UndeployHostedEngine(*p.undeployHostedEngine)
 	}
@@ -40284,7 +40357,7 @@ func (p *HostsService) AddUsingRootPassword() *HostsServiceAddUsingRootPasswordR
 }
 
 //
-// Add a new host to the system providing the ssh password or fingerprint.
+// Add a new host to the system providing the ssh password, fingerprint or public key.
 //
 type HostsServiceAddUsingSshRequest struct {
 	HostsService         *HostsService
@@ -40293,6 +40366,7 @@ type HostsServiceAddUsingSshRequest struct {
 	activate             *bool
 	deployHostedEngine   *bool
 	host                 *Host
+	reboot               *bool
 	undeployHostedEngine *bool
 }
 
@@ -40327,6 +40401,11 @@ func (p *HostsServiceAddUsingSshRequest) Host(host *Host) *HostsServiceAddUsingS
 	return p
 }
 
+func (p *HostsServiceAddUsingSshRequest) Reboot(reboot bool) *HostsServiceAddUsingSshRequest {
+	p.reboot = &reboot
+	return p
+}
+
 func (p *HostsServiceAddUsingSshRequest) UndeployHostedEngine(undeployHostedEngine bool) *HostsServiceAddUsingSshRequest {
 	p.undeployHostedEngine = &undeployHostedEngine
 	return p
@@ -40342,6 +40421,9 @@ func (p *HostsServiceAddUsingSshRequest) Send() (*HostsServiceAddUsingSshRespons
 		actionBuilder.DeployHostedEngine(*p.deployHostedEngine)
 	}
 	actionBuilder.Host(p.host)
+	if p.reboot != nil {
+		actionBuilder.Reboot(*p.reboot)
+	}
 	if p.undeployHostedEngine != nil {
 		actionBuilder.UndeployHostedEngine(*p.undeployHostedEngine)
 	}
@@ -40421,7 +40503,7 @@ func (p *HostsServiceAddUsingSshRequest) MustSend() *HostsServiceAddUsingSshResp
 }
 
 //
-// Add a new host to the system providing the ssh password or fingerprint.
+// Add a new host to the system providing the ssh password, fingerprint or public key.
 //
 type HostsServiceAddUsingSshResponse struct {
 	host *Host
@@ -40442,7 +40524,7 @@ func (p *HostsServiceAddUsingSshResponse) MustHost() *Host {
 }
 
 //
-// Add a new host to the system providing the ssh password or fingerprint.
+// Add a new host to the system providing the ssh password, fingerprint or public key.
 //
 func (p *HostsService) AddUsingSsh() *HostsServiceAddUsingSshRequest {
 	return &HostsServiceAddUsingSshRequest{HostsService: p}
@@ -96680,6 +96762,175 @@ func NewVmService(connection *Connection, path string) *VmService {
 }
 
 //
+// Apply an automatic CPU and NUMA configuration on the VM.
+// An example for a request:
+// [source]
+// ----
+// POST /ovirt-engine/api/vms/123/autopincpuandnumanodes
+// ----
+// With a request body like this:
+// [source,xml]
+// ----
+// <action>
+//   <optimize_cpu_settings>true</optimize_cpu_settings>
+// </action>
+// ----
+//
+type VmServiceAutoPinCpuAndNumaNodesRequest struct {
+	VmService           *VmService
+	header              map[string]string
+	query               map[string]string
+	async               *bool
+	optimizeCpuSettings *bool
+}
+
+func (p *VmServiceAutoPinCpuAndNumaNodesRequest) Header(key, value string) *VmServiceAutoPinCpuAndNumaNodesRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *VmServiceAutoPinCpuAndNumaNodesRequest) Query(key, value string) *VmServiceAutoPinCpuAndNumaNodesRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *VmServiceAutoPinCpuAndNumaNodesRequest) Async(async bool) *VmServiceAutoPinCpuAndNumaNodesRequest {
+	p.async = &async
+	return p
+}
+
+func (p *VmServiceAutoPinCpuAndNumaNodesRequest) OptimizeCpuSettings(optimizeCpuSettings bool) *VmServiceAutoPinCpuAndNumaNodesRequest {
+	p.optimizeCpuSettings = &optimizeCpuSettings
+	return p
+}
+
+func (p *VmServiceAutoPinCpuAndNumaNodesRequest) Send() (*VmServiceAutoPinCpuAndNumaNodesResponse, error) {
+	rawURL := fmt.Sprintf("%s%s/autopincpuandnumanodes", p.VmService.connection.URL(), p.VmService.path)
+	actionBuilder := NewActionBuilder()
+	if p.async != nil {
+		actionBuilder.Async(*p.async)
+	}
+	if p.optimizeCpuSettings != nil {
+		actionBuilder.OptimizeCpuSettings(*p.optimizeCpuSettings)
+	}
+	action, err := actionBuilder.Build()
+	if err != nil {
+		return nil, err
+	}
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	var body bytes.Buffer
+	writer := NewXMLWriter(&body)
+	err = XMLActionWriteOne(writer, action, "")
+	writer.Flush()
+	req, err := http.NewRequest("POST", rawURL, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.VmService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.VmService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.VmService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.VmService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.VmService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	_, errCheckAction := CheckAction(resp)
+	if errCheckAction != nil {
+		return nil, errCheckAction
+	}
+	return new(VmServiceAutoPinCpuAndNumaNodesResponse), nil
+}
+
+func (p *VmServiceAutoPinCpuAndNumaNodesRequest) MustSend() *VmServiceAutoPinCpuAndNumaNodesResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Apply an automatic CPU and NUMA configuration on the VM.
+// An example for a request:
+// [source]
+// ----
+// POST /ovirt-engine/api/vms/123/autopincpuandnumanodes
+// ----
+// With a request body like this:
+// [source,xml]
+// ----
+// <action>
+//   <optimize_cpu_settings>true</optimize_cpu_settings>
+// </action>
+// ----
+//
+type VmServiceAutoPinCpuAndNumaNodesResponse struct {
+}
+
+//
+// Apply an automatic CPU and NUMA configuration on the VM.
+// An example for a request:
+// [source]
+// ----
+// POST /ovirt-engine/api/vms/123/autopincpuandnumanodes
+// ----
+// With a request body like this:
+// [source,xml]
+// ----
+// <action>
+//   <optimize_cpu_settings>true</optimize_cpu_settings>
+// </action>
+// ----
+//
+func (p *VmService) AutoPinCpuAndNumaNodes() *VmServiceAutoPinCpuAndNumaNodesRequest {
+	return &VmServiceAutoPinCpuAndNumaNodesRequest{VmService: p}
+}
+
+//
 // This operation stops any migration of a virtual machine to another physical host.
 // [source]
 // ----
@@ -98572,12 +98823,25 @@ func (p *VmService) PreviewSnapshot() *VmServicePreviewSnapshotRequest {
 // ----
 // <action/>
 // ----
+// To reboot the VM even if a backup is running for it,
+// the action should include the 'force' element.
+// For example, to force reboot virtual machine `123`:
+// ----
+// POST /ovirt-engine/api/vms/123/reboot
+// ----
+// [source,xml]
+// ----
+// <action>
+//     <force>true</force>
+// </action>
+// ----
 //
 type VmServiceRebootRequest struct {
 	VmService *VmService
 	header    map[string]string
 	query     map[string]string
 	async     *bool
+	force     *bool
 }
 
 func (p *VmServiceRebootRequest) Header(key, value string) *VmServiceRebootRequest {
@@ -98601,11 +98865,19 @@ func (p *VmServiceRebootRequest) Async(async bool) *VmServiceRebootRequest {
 	return p
 }
 
+func (p *VmServiceRebootRequest) Force(force bool) *VmServiceRebootRequest {
+	p.force = &force
+	return p
+}
+
 func (p *VmServiceRebootRequest) Send() (*VmServiceRebootResponse, error) {
 	rawURL := fmt.Sprintf("%s%s/reboot", p.VmService.connection.URL(), p.VmService.path)
 	actionBuilder := NewActionBuilder()
 	if p.async != nil {
 		actionBuilder.Async(*p.async)
+	}
+	if p.force != nil {
+		actionBuilder.Force(*p.force)
 	}
 	action, err := actionBuilder.Build()
 	if err != nil {
@@ -98694,6 +98966,18 @@ func (p *VmServiceRebootRequest) MustSend() *VmServiceRebootResponse {
 // ----
 // <action/>
 // ----
+// To reboot the VM even if a backup is running for it,
+// the action should include the 'force' element.
+// For example, to force reboot virtual machine `123`:
+// ----
+// POST /ovirt-engine/api/vms/123/reboot
+// ----
+// [source,xml]
+// ----
+// <action>
+//     <force>true</force>
+// </action>
+// ----
 //
 type VmServiceRebootResponse struct {
 }
@@ -98710,6 +98994,18 @@ type VmServiceRebootResponse struct {
 // [source,xml]
 // ----
 // <action/>
+// ----
+// To reboot the VM even if a backup is running for it,
+// the action should include the 'force' element.
+// For example, to force reboot virtual machine `123`:
+// ----
+// POST /ovirt-engine/api/vms/123/reboot
+// ----
+// [source,xml]
+// ----
+// <action>
+//     <force>true</force>
+// </action>
 // ----
 //
 func (p *VmService) Reboot() *VmServiceRebootRequest {
@@ -99004,12 +99300,25 @@ func (p *VmService) ReorderMacAddresses() *VmServiceReorderMacAddressesRequest {
 // ----
 // <action/>
 // ----
+// To shutdown the VM even if a backup is running for it,
+// the action should include the 'force' element.
+// For example, to force shutdown virtual machine `123`:
+// ----
+// POST /ovirt-engine/api/vms/123/shutdown
+// ----
+// [source,xml]
+// ----
+// <action>
+//     <force>true</force>
+// </action>
+// ----
 //
 type VmServiceShutdownRequest struct {
 	VmService *VmService
 	header    map[string]string
 	query     map[string]string
 	async     *bool
+	force     *bool
 	reason    *string
 }
 
@@ -99034,6 +99343,11 @@ func (p *VmServiceShutdownRequest) Async(async bool) *VmServiceShutdownRequest {
 	return p
 }
 
+func (p *VmServiceShutdownRequest) Force(force bool) *VmServiceShutdownRequest {
+	p.force = &force
+	return p
+}
+
 func (p *VmServiceShutdownRequest) Reason(reason string) *VmServiceShutdownRequest {
 	p.reason = &reason
 	return p
@@ -99044,6 +99358,9 @@ func (p *VmServiceShutdownRequest) Send() (*VmServiceShutdownResponse, error) {
 	actionBuilder := NewActionBuilder()
 	if p.async != nil {
 		actionBuilder.Async(*p.async)
+	}
+	if p.force != nil {
+		actionBuilder.Force(*p.force)
 	}
 	if p.reason != nil {
 		actionBuilder.Reason(*p.reason)
@@ -99135,6 +99452,18 @@ func (p *VmServiceShutdownRequest) MustSend() *VmServiceShutdownResponse {
 // ----
 // <action/>
 // ----
+// To shutdown the VM even if a backup is running for it,
+// the action should include the 'force' element.
+// For example, to force shutdown virtual machine `123`:
+// ----
+// POST /ovirt-engine/api/vms/123/shutdown
+// ----
+// [source,xml]
+// ----
+// <action>
+//     <force>true</force>
+// </action>
+// ----
 //
 type VmServiceShutdownResponse struct {
 }
@@ -99151,6 +99480,18 @@ type VmServiceShutdownResponse struct {
 // [source,xml]
 // ----
 // <action/>
+// ----
+// To shutdown the VM even if a backup is running for it,
+// the action should include the 'force' element.
+// For example, to force shutdown virtual machine `123`:
+// ----
+// POST /ovirt-engine/api/vms/123/shutdown
+// ----
+// [source,xml]
+// ----
+// <action>
+//     <force>true</force>
+// </action>
 // ----
 //
 func (p *VmService) Shutdown() *VmServiceShutdownRequest {
@@ -99407,12 +99748,25 @@ func (p *VmService) Start() *VmServiceStartRequest {
 // ----
 // <action/>
 // ----
+// To stop the VM even if a backup is running for it,
+// the action should include the 'force' element.
+// For example, to force stop virtual machine `123`:
+// ----
+// POST /ovirt-engine/api/vms/123/stop
+// ----
+// [source,xml]
+// ----
+// <action>
+//     <force>true</force>
+// </action>
+// ----
 //
 type VmServiceStopRequest struct {
 	VmService *VmService
 	header    map[string]string
 	query     map[string]string
 	async     *bool
+	force     *bool
 	reason    *string
 }
 
@@ -99437,6 +99791,11 @@ func (p *VmServiceStopRequest) Async(async bool) *VmServiceStopRequest {
 	return p
 }
 
+func (p *VmServiceStopRequest) Force(force bool) *VmServiceStopRequest {
+	p.force = &force
+	return p
+}
+
 func (p *VmServiceStopRequest) Reason(reason string) *VmServiceStopRequest {
 	p.reason = &reason
 	return p
@@ -99447,6 +99806,9 @@ func (p *VmServiceStopRequest) Send() (*VmServiceStopResponse, error) {
 	actionBuilder := NewActionBuilder()
 	if p.async != nil {
 		actionBuilder.Async(*p.async)
+	}
+	if p.force != nil {
+		actionBuilder.Force(*p.force)
 	}
 	if p.reason != nil {
 		actionBuilder.Reason(*p.reason)
@@ -99538,6 +99900,18 @@ func (p *VmServiceStopRequest) MustSend() *VmServiceStopResponse {
 // ----
 // <action/>
 // ----
+// To stop the VM even if a backup is running for it,
+// the action should include the 'force' element.
+// For example, to force stop virtual machine `123`:
+// ----
+// POST /ovirt-engine/api/vms/123/stop
+// ----
+// [source,xml]
+// ----
+// <action>
+//     <force>true</force>
+// </action>
+// ----
 //
 type VmServiceStopResponse struct {
 }
@@ -99554,6 +99928,18 @@ type VmServiceStopResponse struct {
 // [source,xml]
 // ----
 // <action/>
+// ----
+// To stop the VM even if a backup is running for it,
+// the action should include the 'force' element.
+// For example, to force stop virtual machine `123`:
+// ----
+// POST /ovirt-engine/api/vms/123/stop
+// ----
+// [source,xml]
+// ----
+// <action>
+//     <force>true</force>
+// </action>
 // ----
 //
 func (p *VmService) Stop() *VmServiceStopRequest {
@@ -108428,6 +108814,931 @@ func (op *SshPublicKeysService) String() string {
 }
 
 //
+//
+type UserOptionService struct {
+	BaseService
+}
+
+func NewUserOptionService(connection *Connection, path string) *UserOptionService {
+	var result UserOptionService
+	result.connection = connection
+	result.path = path
+	return &result
+}
+
+//
+// Returns a user profile property of type JSON.
+// Example request(for user with identifier `123` and option with identifier `456`):
+// [source]
+// ----
+// GET /ovirt-engine/api/users/123/options/456
+// ----
+// The result will be the following XML document:
+// [source,xml]
+// ----
+//   <user_option href="/ovirt-engine/api/users/123/options/456" id="456">
+//     <name>SomeName</name>
+//     <content>["any", "JSON"]</content>
+//     <user href="/ovirt-engine/api/users/123" id="123"/>
+//   </user_option>
+// ----
+//
+type UserOptionServiceGetRequest struct {
+	UserOptionService *UserOptionService
+	header            map[string]string
+	query             map[string]string
+}
+
+func (p *UserOptionServiceGetRequest) Header(key, value string) *UserOptionServiceGetRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *UserOptionServiceGetRequest) Query(key, value string) *UserOptionServiceGetRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *UserOptionServiceGetRequest) Send() (*UserOptionServiceGetResponse, error) {
+	rawURL := fmt.Sprintf("%s%s", p.UserOptionService.connection.URL(), p.UserOptionService.path)
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	req, err := http.NewRequest("GET", rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.UserOptionService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.UserOptionService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.UserOptionService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.UserOptionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.UserOptionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	if !Contains(resp.StatusCode, []int{200}) {
+		return nil, CheckFault(resp)
+	}
+	respBodyBytes, errReadBody := ioutil.ReadAll(resp.Body)
+	if errReadBody != nil {
+		return nil, errReadBody
+	}
+	reader := NewXMLReader(respBodyBytes)
+	result, err := XMLUserOptionReadOne(reader, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	return &UserOptionServiceGetResponse{option: result}, nil
+}
+
+func (p *UserOptionServiceGetRequest) MustSend() *UserOptionServiceGetResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Returns a user profile property of type JSON.
+// Example request(for user with identifier `123` and option with identifier `456`):
+// [source]
+// ----
+// GET /ovirt-engine/api/users/123/options/456
+// ----
+// The result will be the following XML document:
+// [source,xml]
+// ----
+//   <user_option href="/ovirt-engine/api/users/123/options/456" id="456">
+//     <name>SomeName</name>
+//     <content>["any", "JSON"]</content>
+//     <user href="/ovirt-engine/api/users/123" id="123"/>
+//   </user_option>
+// ----
+//
+type UserOptionServiceGetResponse struct {
+	option *UserOption
+}
+
+func (p *UserOptionServiceGetResponse) Option() (*UserOption, bool) {
+	if p.option != nil {
+		return p.option, true
+	}
+	return nil, false
+}
+
+func (p *UserOptionServiceGetResponse) MustOption() *UserOption {
+	if p.option == nil {
+		panic("option in response does not exist")
+	}
+	return p.option
+}
+
+//
+// Returns a user profile property of type JSON.
+// Example request(for user with identifier `123` and option with identifier `456`):
+// [source]
+// ----
+// GET /ovirt-engine/api/users/123/options/456
+// ----
+// The result will be the following XML document:
+// [source,xml]
+// ----
+//   <user_option href="/ovirt-engine/api/users/123/options/456" id="456">
+//     <name>SomeName</name>
+//     <content>["any", "JSON"]</content>
+//     <user href="/ovirt-engine/api/users/123" id="123"/>
+//   </user_option>
+// ----
+//
+func (p *UserOptionService) Get() *UserOptionServiceGetRequest {
+	return &UserOptionServiceGetRequest{UserOptionService: p}
+}
+
+//
+// Deletes an existing property of type JSON.
+// Example request(for user with identifier `123` and option with identifier `456`):
+// [source]
+// ----
+// DELETE /ovirt-engine/api/users/123/options/456
+// ----
+//
+type UserOptionServiceRemoveRequest struct {
+	UserOptionService *UserOptionService
+	header            map[string]string
+	query             map[string]string
+}
+
+func (p *UserOptionServiceRemoveRequest) Header(key, value string) *UserOptionServiceRemoveRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *UserOptionServiceRemoveRequest) Query(key, value string) *UserOptionServiceRemoveRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *UserOptionServiceRemoveRequest) Send() (*UserOptionServiceRemoveResponse, error) {
+	rawURL := fmt.Sprintf("%s%s", p.UserOptionService.connection.URL(), p.UserOptionService.path)
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	req, err := http.NewRequest("DELETE", rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.UserOptionService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.UserOptionService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.UserOptionService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.UserOptionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.UserOptionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	if !Contains(resp.StatusCode, []int{200}) {
+		return nil, CheckFault(resp)
+	}
+	_, errReadBody := ioutil.ReadAll(resp.Body)
+	if errReadBody != nil {
+		return nil, errReadBody
+	}
+	return new(UserOptionServiceRemoveResponse), nil
+}
+
+func (p *UserOptionServiceRemoveRequest) MustSend() *UserOptionServiceRemoveResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Deletes an existing property of type JSON.
+// Example request(for user with identifier `123` and option with identifier `456`):
+// [source]
+// ----
+// DELETE /ovirt-engine/api/users/123/options/456
+// ----
+//
+type UserOptionServiceRemoveResponse struct {
+}
+
+//
+// Deletes an existing property of type JSON.
+// Example request(for user with identifier `123` and option with identifier `456`):
+// [source]
+// ----
+// DELETE /ovirt-engine/api/users/123/options/456
+// ----
+//
+func (p *UserOptionService) Remove() *UserOptionServiceRemoveRequest {
+	return &UserOptionServiceRemoveRequest{UserOptionService: p}
+}
+
+//
+// Replaces an existing property of type JSON with a new one.
+// Example request(for user with identifier `123` and option with identifier `456`):
+// [source]
+// ----
+// PUT /ovirt-engine/api/users/123/options/456
+// ----
+// Payload:
+// [source,xml]
+// ----
+// <user_option>
+//   <name>SomeName</name>
+//   <content>{"new" : "JSON"}</content>
+// </user_option>
+// ----
+// The result will be the following XML document:
+// [source,xml]
+// ----
+// <user_option href="/ovirt-engine/api/users/123/options/789" id="789">
+//   <name>SomeName</name>
+//   <content>{"new" : "JSON"}</content>
+//   <user href="/ovirt-engine/api/users/123" id="123"/>
+// </user_option>
+// ----
+//
+type UserOptionServiceUpdateRequest struct {
+	UserOptionService *UserOptionService
+	header            map[string]string
+	query             map[string]string
+	option            *UserOption
+}
+
+func (p *UserOptionServiceUpdateRequest) Header(key, value string) *UserOptionServiceUpdateRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *UserOptionServiceUpdateRequest) Query(key, value string) *UserOptionServiceUpdateRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *UserOptionServiceUpdateRequest) Option(option *UserOption) *UserOptionServiceUpdateRequest {
+	p.option = option
+	return p
+}
+
+func (p *UserOptionServiceUpdateRequest) Send() (*UserOptionServiceUpdateResponse, error) {
+	rawURL := fmt.Sprintf("%s%s", p.UserOptionService.connection.URL(), p.UserOptionService.path)
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	var body bytes.Buffer
+	writer := NewXMLWriter(&body)
+	err := XMLUserOptionWriteOne(writer, p.option, "")
+	if err != nil {
+		return nil, err
+	}
+	writer.Flush()
+	req, err := http.NewRequest("PUT", rawURL, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.UserOptionService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.UserOptionService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.UserOptionService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.UserOptionService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.UserOptionService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	if !Contains(resp.StatusCode, []int{200}) {
+		return nil, CheckFault(resp)
+	}
+	respBodyBytes, errReadBody := ioutil.ReadAll(resp.Body)
+	if errReadBody != nil {
+		return nil, errReadBody
+	}
+	reader := NewXMLReader(respBodyBytes)
+	result, err := XMLUserOptionReadOne(reader, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	return &UserOptionServiceUpdateResponse{option: result}, nil
+}
+
+func (p *UserOptionServiceUpdateRequest) MustSend() *UserOptionServiceUpdateResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Replaces an existing property of type JSON with a new one.
+// Example request(for user with identifier `123` and option with identifier `456`):
+// [source]
+// ----
+// PUT /ovirt-engine/api/users/123/options/456
+// ----
+// Payload:
+// [source,xml]
+// ----
+// <user_option>
+//   <name>SomeName</name>
+//   <content>{"new" : "JSON"}</content>
+// </user_option>
+// ----
+// The result will be the following XML document:
+// [source,xml]
+// ----
+// <user_option href="/ovirt-engine/api/users/123/options/789" id="789">
+//   <name>SomeName</name>
+//   <content>{"new" : "JSON"}</content>
+//   <user href="/ovirt-engine/api/users/123" id="123"/>
+// </user_option>
+// ----
+//
+type UserOptionServiceUpdateResponse struct {
+	option *UserOption
+}
+
+func (p *UserOptionServiceUpdateResponse) Option() (*UserOption, bool) {
+	if p.option != nil {
+		return p.option, true
+	}
+	return nil, false
+}
+
+func (p *UserOptionServiceUpdateResponse) MustOption() *UserOption {
+	if p.option == nil {
+		panic("option in response does not exist")
+	}
+	return p.option
+}
+
+//
+// Replaces an existing property of type JSON with a new one.
+// Example request(for user with identifier `123` and option with identifier `456`):
+// [source]
+// ----
+// PUT /ovirt-engine/api/users/123/options/456
+// ----
+// Payload:
+// [source,xml]
+// ----
+// <user_option>
+//   <name>SomeName</name>
+//   <content>{"new" : "JSON"}</content>
+// </user_option>
+// ----
+// The result will be the following XML document:
+// [source,xml]
+// ----
+// <user_option href="/ovirt-engine/api/users/123/options/789" id="789">
+//   <name>SomeName</name>
+//   <content>{"new" : "JSON"}</content>
+//   <user href="/ovirt-engine/api/users/123" id="123"/>
+// </user_option>
+// ----
+//
+func (p *UserOptionService) Update() *UserOptionServiceUpdateRequest {
+	return &UserOptionServiceUpdateRequest{UserOptionService: p}
+}
+
+//
+// Service locator method, returns individual service on which the URI is dispatched.
+//
+func (op *UserOptionService) Service(path string) (Service, error) {
+	if path == "" {
+		return op, nil
+	}
+	return nil, fmt.Errorf("The path <%s> doesn't correspond to any service", path)
+}
+
+func (op *UserOptionService) String() string {
+	return fmt.Sprintf("UserOptionService:%s", op.path)
+}
+
+//
+//
+type UserOptionsService struct {
+	BaseService
+}
+
+func NewUserOptionsService(connection *Connection, path string) *UserOptionsService {
+	var result UserOptionsService
+	result.connection = connection
+	result.path = path
+	return &result
+}
+
+//
+// Adds a new user profile property of type JSON.
+// Example request(for user with identifier `123`):
+// [source]
+// ----
+// POST /ovirt-engine/api/users/123/options
+// ----
+// Payload:
+// [source,xml]
+// ----
+//   <user_option>
+//     <name>SomeName</name>
+//     <content>["any", "JSON"]</content>
+//   </user_option>
+// ----
+//
+type UserOptionsServiceAddRequest struct {
+	UserOptionsService *UserOptionsService
+	header             map[string]string
+	query              map[string]string
+	option             *UserOption
+}
+
+func (p *UserOptionsServiceAddRequest) Header(key, value string) *UserOptionsServiceAddRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *UserOptionsServiceAddRequest) Query(key, value string) *UserOptionsServiceAddRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *UserOptionsServiceAddRequest) Option(option *UserOption) *UserOptionsServiceAddRequest {
+	p.option = option
+	return p
+}
+
+func (p *UserOptionsServiceAddRequest) Send() (*UserOptionsServiceAddResponse, error) {
+	rawURL := fmt.Sprintf("%s%s", p.UserOptionsService.connection.URL(), p.UserOptionsService.path)
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	var body bytes.Buffer
+	writer := NewXMLWriter(&body)
+	err := XMLUserOptionWriteOne(writer, p.option, "")
+	if err != nil {
+		return nil, err
+	}
+	writer.Flush()
+	req, err := http.NewRequest("POST", rawURL, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.UserOptionsService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.UserOptionsService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.UserOptionsService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.UserOptionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.UserOptionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	if !Contains(resp.StatusCode, []int{200, 201, 202}) {
+		return nil, CheckFault(resp)
+	}
+	respBodyBytes, errReadBody := ioutil.ReadAll(resp.Body)
+	if errReadBody != nil {
+		return nil, errReadBody
+	}
+	reader := NewXMLReader(respBodyBytes)
+	result, err := XMLUserOptionReadOne(reader, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	return &UserOptionsServiceAddResponse{option: result}, nil
+}
+
+func (p *UserOptionsServiceAddRequest) MustSend() *UserOptionsServiceAddResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Adds a new user profile property of type JSON.
+// Example request(for user with identifier `123`):
+// [source]
+// ----
+// POST /ovirt-engine/api/users/123/options
+// ----
+// Payload:
+// [source,xml]
+// ----
+//   <user_option>
+//     <name>SomeName</name>
+//     <content>["any", "JSON"]</content>
+//   </user_option>
+// ----
+//
+type UserOptionsServiceAddResponse struct {
+	option *UserOption
+}
+
+func (p *UserOptionsServiceAddResponse) Option() (*UserOption, bool) {
+	if p.option != nil {
+		return p.option, true
+	}
+	return nil, false
+}
+
+func (p *UserOptionsServiceAddResponse) MustOption() *UserOption {
+	if p.option == nil {
+		panic("option in response does not exist")
+	}
+	return p.option
+}
+
+//
+// Adds a new user profile property of type JSON.
+// Example request(for user with identifier `123`):
+// [source]
+// ----
+// POST /ovirt-engine/api/users/123/options
+// ----
+// Payload:
+// [source,xml]
+// ----
+//   <user_option>
+//     <name>SomeName</name>
+//     <content>["any", "JSON"]</content>
+//   </user_option>
+// ----
+//
+func (p *UserOptionsService) Add() *UserOptionsServiceAddRequest {
+	return &UserOptionsServiceAddRequest{UserOptionsService: p}
+}
+
+//
+// Returns a list of user profile properties of type JSON.
+// Example request(for user with identifier `123`):
+// [source]
+// ----
+// GET /ovirt-engine/api/users/123/options
+// ----
+// The result will be the following XML document:
+// [source,xml]
+// ----
+// <user_options>
+//   <user_option href="/ovirt-engine/api/users/123/options/456" id="456">
+//     <name>SomeName</name>
+//     <content>["any", "JSON"]</content>
+//     <user href="/ovirt-engine/api/users/123" id="123"/>
+//   </user_option>
+// </user_options>
+// ----
+//
+type UserOptionsServiceListRequest struct {
+	UserOptionsService *UserOptionsService
+	header             map[string]string
+	query              map[string]string
+}
+
+func (p *UserOptionsServiceListRequest) Header(key, value string) *UserOptionsServiceListRequest {
+	if p.header == nil {
+		p.header = make(map[string]string)
+	}
+	p.header[key] = value
+	return p
+}
+
+func (p *UserOptionsServiceListRequest) Query(key, value string) *UserOptionsServiceListRequest {
+	if p.query == nil {
+		p.query = make(map[string]string)
+	}
+	p.query[key] = value
+	return p
+}
+
+func (p *UserOptionsServiceListRequest) Send() (*UserOptionsServiceListResponse, error) {
+	rawURL := fmt.Sprintf("%s%s", p.UserOptionsService.connection.URL(), p.UserOptionsService.path)
+	values := make(url.Values)
+	if p.query != nil {
+		for k, v := range p.query {
+			values[k] = []string{v}
+		}
+	}
+	if len(values) > 0 {
+		rawURL = fmt.Sprintf("%s?%s", rawURL, values.Encode())
+	}
+	req, err := http.NewRequest("GET", rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for hk, hv := range p.UserOptionsService.connection.headers {
+		req.Header.Add(hk, hv)
+	}
+
+	if p.header != nil {
+		for hk, hv := range p.header {
+			req.Header.Add(hk, hv)
+		}
+	}
+
+	req.Header.Add("User-Agent", fmt.Sprintf("GoSDK/%s", SDK_VERSION))
+	req.Header.Add("Version", "4")
+	req.Header.Add("Content-Type", "application/xml")
+	req.Header.Add("Accept", "application/xml")
+	// get OAuth access token
+	token, err := p.UserOptionsService.connection.authenticate()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	// Send the request and wait for the response
+	resp, err := p.UserOptionsService.connection.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if p.UserOptionsService.connection.logFunc != nil {
+		dumpReq, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		dumpResp, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		p.UserOptionsService.connection.logFunc("<<<<<<Request:\n%sResponse:\n%s>>>>>>\n", string(dumpReq), string(dumpResp))
+	}
+	if !Contains(resp.StatusCode, []int{200}) {
+		return nil, CheckFault(resp)
+	}
+	respBodyBytes, errReadBody := ioutil.ReadAll(resp.Body)
+	if errReadBody != nil {
+		return nil, errReadBody
+	}
+	reader := NewXMLReader(respBodyBytes)
+	result, err := XMLUserOptionReadMany(reader, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &UserOptionsServiceListResponse{options: result}, nil
+}
+
+func (p *UserOptionsServiceListRequest) MustSend() *UserOptionsServiceListResponse {
+	if v, err := p.Send(); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
+//
+// Returns a list of user profile properties of type JSON.
+// Example request(for user with identifier `123`):
+// [source]
+// ----
+// GET /ovirt-engine/api/users/123/options
+// ----
+// The result will be the following XML document:
+// [source,xml]
+// ----
+// <user_options>
+//   <user_option href="/ovirt-engine/api/users/123/options/456" id="456">
+//     <name>SomeName</name>
+//     <content>["any", "JSON"]</content>
+//     <user href="/ovirt-engine/api/users/123" id="123"/>
+//   </user_option>
+// </user_options>
+// ----
+//
+type UserOptionsServiceListResponse struct {
+	options *UserOptionSlice
+}
+
+func (p *UserOptionsServiceListResponse) Options() (*UserOptionSlice, bool) {
+	if p.options != nil {
+		return p.options, true
+	}
+	return nil, false
+}
+
+func (p *UserOptionsServiceListResponse) MustOptions() *UserOptionSlice {
+	if p.options == nil {
+		panic("options in response does not exist")
+	}
+	return p.options
+}
+
+//
+// Returns a list of user profile properties of type JSON.
+// Example request(for user with identifier `123`):
+// [source]
+// ----
+// GET /ovirt-engine/api/users/123/options
+// ----
+// The result will be the following XML document:
+// [source,xml]
+// ----
+// <user_options>
+//   <user_option href="/ovirt-engine/api/users/123/options/456" id="456">
+//     <name>SomeName</name>
+//     <content>["any", "JSON"]</content>
+//     <user href="/ovirt-engine/api/users/123" id="123"/>
+//   </user_option>
+// </user_options>
+// ----
+//
+func (p *UserOptionsService) List() *UserOptionsServiceListRequest {
+	return &UserOptionsServiceListRequest{UserOptionsService: p}
+}
+
+//
+//
+func (op *UserOptionsService) OptionService(id string) *UserOptionService {
+	return NewUserOptionService(op.connection, fmt.Sprintf("%s/%s", op.path, id))
+}
+
+//
+// Service locator method, returns individual service on which the URI is dispatched.
+//
+func (op *UserOptionsService) Service(path string) (Service, error) {
+	if path == "" {
+		return op, nil
+	}
+	index := strings.Index(path, "/")
+	if index == -1 {
+		return op.OptionService(path), nil
+	}
+	return op.OptionService(path[:index]).Service(path[index+1:])
+}
+
+func (op *UserOptionsService) String() string {
+	return fmt.Sprintf("UserOptionsService:%s", op.path)
+}
+
+//
 // A service to manage a user in the system.
 // Use this service to either get users details or remove users.
 // In order to add new users please use
@@ -108804,7 +110115,7 @@ func (p *UserService) Remove() *UserServiceRemoveRequest {
 //    <user_options>
 //       <property>
 //          <name>test</name>
-//          <value>test1</value>
+//          <value>["any","JSON"]</value>
 //       </property>
 //    </user_options>
 // </user>
@@ -108936,7 +110247,7 @@ func (p *UserServiceUpdateRequest) MustSend() *UserServiceUpdateResponse {
 //    <user_options>
 //       <property>
 //          <name>test</name>
-//          <value>test1</value>
+//          <value>["any","JSON"]</value>
 //       </property>
 //    </user_options>
 // </user>
@@ -108975,7 +110286,7 @@ func (p *UserServiceUpdateResponse) MustUser() *User {
 //    <user_options>
 //       <property>
 //          <name>test</name>
-//          <value>test1</value>
+//          <value>["any","JSON"]</value>
 //       </property>
 //    </user_options>
 // </user>
@@ -108996,6 +110307,12 @@ func (op *UserService) EventSubscriptionsService() *EventSubscriptionsService {
 //
 func (op *UserService) GroupsService() *DomainUserGroupsService {
 	return NewDomainUserGroupsService(op.connection, fmt.Sprintf("%s/groups", op.path))
+}
+
+//
+//
+func (op *UserService) OptionsService() *UserOptionsService {
+	return NewUserOptionsService(op.connection, fmt.Sprintf("%s/options", op.path))
 }
 
 //
@@ -109040,6 +110357,12 @@ func (op *UserService) Service(path string) (Service, error) {
 	}
 	if strings.HasPrefix(path, "groups/") {
 		return op.GroupsService().Service(path[7:])
+	}
+	if path == "options" {
+		return op.OptionsService(), nil
+	}
+	if strings.HasPrefix(path, "options/") {
+		return op.OptionsService().Service(path[8:])
 	}
 	if path == "permissions" {
 		return op.PermissionsService(), nil

--- a/vendor/github.com/ovirt/go-ovirt/types.go
+++ b/vendor/github.com/ovirt/go-ovirt/types.go
@@ -2720,6 +2720,7 @@ type Cluster struct {
 	errorHandling                    *ErrorHandling
 	externalNetworkProviders         *ExternalProviderSlice
 	fencingPolicy                    *FencingPolicy
+	fipsMode                         *FipsMode
 	firewallType                     *FirewallType
 	glusterHooks                     *GlusterHookSlice
 	glusterService                   *bool
@@ -3007,6 +3008,25 @@ func (p *Cluster) MustFencingPolicy() *FencingPolicy {
 		panic("the fencingPolicy must not be nil, please use FencingPolicy() function instead")
 	}
 	return p.fencingPolicy
+}
+
+func (p *Cluster) SetFipsMode(attr FipsMode) {
+	p.fipsMode = &attr
+}
+
+func (p *Cluster) FipsMode() (FipsMode, bool) {
+	if p.fipsMode != nil {
+		return *p.fipsMode, true
+	}
+	var zero FipsMode
+	return zero, false
+}
+
+func (p *Cluster) MustFipsMode() FipsMode {
+	if p.fipsMode == nil {
+		panic("the fipsMode must not be nil, please use FipsMode() function instead")
+	}
+	return *p.fipsMode
 }
 
 func (p *Cluster) SetFirewallType(attr FirewallType) {
@@ -16150,6 +16170,7 @@ type ImageTransfer struct {
 	proxyUrl          *string
 	shallow           *bool
 	snapshot          *DiskSnapshot
+	timeoutPolicy     *ImageTransferTimeoutPolicy
 	transferUrl       *string
 	transferred       *int64
 }
@@ -16451,6 +16472,25 @@ func (p *ImageTransfer) MustSnapshot() *DiskSnapshot {
 		panic("the snapshot must not be nil, please use Snapshot() function instead")
 	}
 	return p.snapshot
+}
+
+func (p *ImageTransfer) SetTimeoutPolicy(attr ImageTransferTimeoutPolicy) {
+	p.timeoutPolicy = &attr
+}
+
+func (p *ImageTransfer) TimeoutPolicy() (ImageTransferTimeoutPolicy, bool) {
+	if p.timeoutPolicy != nil {
+		return *p.timeoutPolicy, true
+	}
+	var zero ImageTransferTimeoutPolicy
+	return zero, false
+}
+
+func (p *ImageTransfer) MustTimeoutPolicy() ImageTransferTimeoutPolicy {
+	if p.timeoutPolicy == nil {
+		panic("the timeoutPolicy must not be nil, please use TimeoutPolicy() function instead")
+	}
+	return *p.timeoutPolicy
 }
 
 func (p *ImageTransfer) SetTransferUrl(attr string) {
@@ -16934,62 +16974,63 @@ func (p *Initialization) MustWindowsLicenseKey() string {
 
 type InstanceType struct {
 	Struct
-	bios                        *Bios
-	cdroms                      *CdromSlice
-	cluster                     *Cluster
-	comment                     *string
-	console                     *Console
-	cpu                         *Cpu
-	cpuProfile                  *CpuProfile
-	cpuShares                   *int64
-	creationTime                *time.Time
-	customCompatibilityVersion  *Version
-	customCpuModel              *string
-	customEmulatedMachine       *string
-	customProperties            *CustomPropertySlice
-	deleteProtected             *bool
-	description                 *string
-	diskAttachments             *DiskAttachmentSlice
-	display                     *Display
-	domain                      *Domain
-	graphicsConsoles            *GraphicsConsoleSlice
-	highAvailability            *HighAvailability
-	id                          *string
-	initialization              *Initialization
-	io                          *Io
-	largeIcon                   *Icon
-	lease                       *StorageDomainLease
-	memory                      *int64
-	memoryPolicy                *MemoryPolicy
-	migration                   *MigrationOptions
-	migrationDowntime           *int64
-	multiQueuesEnabled          *bool
-	name                        *string
-	nics                        *NicSlice
-	origin                      *string
-	os                          *OperatingSystem
-	permissions                 *PermissionSlice
-	placementPolicy             *VmPlacementPolicy
-	quota                       *Quota
-	rngDevice                   *RngDevice
-	serialNumber                *SerialNumber
-	smallIcon                   *Icon
-	soundcardEnabled            *bool
-	sso                         *Sso
-	startPaused                 *bool
-	stateless                   *bool
-	status                      *TemplateStatus
-	storageDomain               *StorageDomain
-	storageErrorResumeBehaviour *VmStorageErrorResumeBehaviour
-	tags                        *TagSlice
-	timeZone                    *TimeZone
-	tunnelMigration             *bool
-	type_                       *VmType
-	usb                         *Usb
-	version                     *TemplateVersion
-	virtioScsi                  *VirtioScsi
-	vm                          *Vm
-	watchdogs                   *WatchdogSlice
+	bios                         *Bios
+	cdroms                       *CdromSlice
+	cluster                      *Cluster
+	comment                      *string
+	console                      *Console
+	cpu                          *Cpu
+	cpuProfile                   *CpuProfile
+	cpuShares                    *int64
+	creationTime                 *time.Time
+	customCompatibilityVersion   *Version
+	customCpuModel               *string
+	customEmulatedMachine        *string
+	customProperties             *CustomPropertySlice
+	deleteProtected              *bool
+	description                  *string
+	diskAttachments              *DiskAttachmentSlice
+	display                      *Display
+	domain                       *Domain
+	graphicsConsoles             *GraphicsConsoleSlice
+	highAvailability             *HighAvailability
+	id                           *string
+	initialization               *Initialization
+	io                           *Io
+	largeIcon                    *Icon
+	lease                        *StorageDomainLease
+	memory                       *int64
+	memoryPolicy                 *MemoryPolicy
+	migration                    *MigrationOptions
+	migrationDowntime            *int64
+	multiQueuesEnabled           *bool
+	name                         *string
+	nics                         *NicSlice
+	origin                       *string
+	os                           *OperatingSystem
+	permissions                  *PermissionSlice
+	placementPolicy              *VmPlacementPolicy
+	quota                        *Quota
+	rngDevice                    *RngDevice
+	serialNumber                 *SerialNumber
+	smallIcon                    *Icon
+	soundcardEnabled             *bool
+	sso                          *Sso
+	startPaused                  *bool
+	stateless                    *bool
+	status                       *TemplateStatus
+	storageDomain                *StorageDomain
+	storageErrorResumeBehaviour  *VmStorageErrorResumeBehaviour
+	tags                         *TagSlice
+	timeZone                     *TimeZone
+	tunnelMigration              *bool
+	type_                        *VmType
+	usb                          *Usb
+	version                      *TemplateVersion
+	virtioScsi                   *VirtioScsi
+	virtioScsiMultiQueuesEnabled *bool
+	vm                           *Vm
+	watchdogs                    *WatchdogSlice
 }
 
 func (p *InstanceType) SetBios(attr *Bios) {
@@ -17982,6 +18023,25 @@ func (p *InstanceType) MustVirtioScsi() *VirtioScsi {
 		panic("the virtioScsi must not be nil, please use VirtioScsi() function instead")
 	}
 	return p.virtioScsi
+}
+
+func (p *InstanceType) SetVirtioScsiMultiQueuesEnabled(attr bool) {
+	p.virtioScsiMultiQueuesEnabled = &attr
+}
+
+func (p *InstanceType) VirtioScsiMultiQueuesEnabled() (bool, bool) {
+	if p.virtioScsiMultiQueuesEnabled != nil {
+		return *p.virtioScsiMultiQueuesEnabled, true
+	}
+	var zero bool
+	return zero, false
+}
+
+func (p *InstanceType) MustVirtioScsiMultiQueuesEnabled() bool {
+	if p.virtioScsiMultiQueuesEnabled == nil {
+		panic("the virtioScsiMultiQueuesEnabled must not be nil, please use VirtioScsiMultiQueuesEnabled() function instead")
+	}
+	return *p.virtioScsiMultiQueuesEnabled
 }
 
 func (p *InstanceType) SetVm(attr *Vm) {
@@ -28084,30 +28144,6 @@ func (p *SchedulingPolicy) MustWeight() *WeightSlice {
 	return p.weight
 }
 
-type SeLinux struct {
-	Struct
-	mode *SeLinuxMode
-}
-
-func (p *SeLinux) SetMode(attr SeLinuxMode) {
-	p.mode = &attr
-}
-
-func (p *SeLinux) Mode() (SeLinuxMode, bool) {
-	if p.mode != nil {
-		return *p.mode, true
-	}
-	var zero SeLinuxMode
-	return zero, false
-}
-
-func (p *SeLinux) MustMode() SeLinuxMode {
-	if p.mode == nil {
-		panic("the mode must not be nil, please use Mode() function instead")
-	}
-	return *p.mode
-}
-
 type SchedulingPolicyUnit struct {
 	Struct
 	comment     *string
@@ -28269,6 +28305,30 @@ func (p *SchedulingPolicyUnit) MustType() PolicyUnitType {
 		panic("the type_ must not be nil, please use Type() function instead")
 	}
 	return *p.type_
+}
+
+type SeLinux struct {
+	Struct
+	mode *SeLinuxMode
+}
+
+func (p *SeLinux) SetMode(attr SeLinuxMode) {
+	p.mode = &attr
+}
+
+func (p *SeLinux) Mode() (SeLinuxMode, bool) {
+	if p.mode != nil {
+		return *p.mode, true
+	}
+	var zero SeLinuxMode
+	return zero, false
+}
+
+func (p *SeLinux) MustMode() SeLinuxMode {
+	if p.mode == nil {
+		panic("the mode must not be nil, please use Mode() function instead")
+	}
+	return *p.mode
 }
 
 type SerialNumber struct {
@@ -28566,95 +28626,96 @@ func (p *SkipIfSdActive) MustEnabled() bool {
 
 type Snapshot struct {
 	Struct
-	affinityLabels              *AffinityLabelSlice
-	applications                *ApplicationSlice
-	bios                        *Bios
-	cdroms                      *CdromSlice
-	cluster                     *Cluster
-	comment                     *string
-	console                     *Console
-	cpu                         *Cpu
-	cpuProfile                  *CpuProfile
-	cpuShares                   *int64
-	creationTime                *time.Time
-	customCompatibilityVersion  *Version
-	customCpuModel              *string
-	customEmulatedMachine       *string
-	customProperties            *CustomPropertySlice
-	date                        *time.Time
-	deleteProtected             *bool
-	description                 *string
-	diskAttachments             *DiskAttachmentSlice
-	disks                       *DiskSlice
-	display                     *Display
-	domain                      *Domain
-	externalHostProvider        *ExternalHostProvider
-	floppies                    *FloppySlice
-	fqdn                        *string
-	graphicsConsoles            *GraphicsConsoleSlice
-	guestOperatingSystem        *GuestOperatingSystem
-	guestTimeZone               *TimeZone
-	hasIllegalImages            *bool
-	highAvailability            *HighAvailability
-	host                        *Host
-	hostDevices                 *HostDeviceSlice
-	id                          *string
-	initialization              *Initialization
-	instanceType                *InstanceType
-	io                          *Io
-	katelloErrata               *KatelloErratumSlice
-	largeIcon                   *Icon
-	lease                       *StorageDomainLease
-	memory                      *int64
-	memoryPolicy                *MemoryPolicy
-	migration                   *MigrationOptions
-	migrationDowntime           *int64
-	multiQueuesEnabled          *bool
-	name                        *string
-	nextRunConfigurationExists  *bool
-	nics                        *NicSlice
-	numaNodes                   *NumaNodeSlice
-	numaTuneMode                *NumaTuneMode
-	origin                      *string
-	originalTemplate            *Template
-	os                          *OperatingSystem
-	payloads                    *PayloadSlice
-	permissions                 *PermissionSlice
-	persistMemorystate          *bool
-	placementPolicy             *VmPlacementPolicy
-	quota                       *Quota
-	reportedDevices             *ReportedDeviceSlice
-	rngDevice                   *RngDevice
-	runOnce                     *bool
-	serialNumber                *SerialNumber
-	sessions                    *SessionSlice
-	smallIcon                   *Icon
-	snapshotStatus              *SnapshotStatus
-	snapshotType                *SnapshotType
-	snapshots                   *SnapshotSlice
-	soundcardEnabled            *bool
-	sso                         *Sso
-	startPaused                 *bool
-	startTime                   *time.Time
-	stateless                   *bool
-	statistics                  *StatisticSlice
-	status                      *VmStatus
-	statusDetail                *string
-	stopReason                  *string
-	stopTime                    *time.Time
-	storageDomain               *StorageDomain
-	storageErrorResumeBehaviour *VmStorageErrorResumeBehaviour
-	tags                        *TagSlice
-	template                    *Template
-	timeZone                    *TimeZone
-	tunnelMigration             *bool
-	type_                       *VmType
-	usb                         *Usb
-	useLatestTemplateVersion    *bool
-	virtioScsi                  *VirtioScsi
-	vm                          *Vm
-	vmPool                      *VmPool
-	watchdogs                   *WatchdogSlice
+	affinityLabels               *AffinityLabelSlice
+	applications                 *ApplicationSlice
+	bios                         *Bios
+	cdroms                       *CdromSlice
+	cluster                      *Cluster
+	comment                      *string
+	console                      *Console
+	cpu                          *Cpu
+	cpuProfile                   *CpuProfile
+	cpuShares                    *int64
+	creationTime                 *time.Time
+	customCompatibilityVersion   *Version
+	customCpuModel               *string
+	customEmulatedMachine        *string
+	customProperties             *CustomPropertySlice
+	date                         *time.Time
+	deleteProtected              *bool
+	description                  *string
+	diskAttachments              *DiskAttachmentSlice
+	disks                        *DiskSlice
+	display                      *Display
+	domain                       *Domain
+	externalHostProvider         *ExternalHostProvider
+	floppies                     *FloppySlice
+	fqdn                         *string
+	graphicsConsoles             *GraphicsConsoleSlice
+	guestOperatingSystem         *GuestOperatingSystem
+	guestTimeZone                *TimeZone
+	hasIllegalImages             *bool
+	highAvailability             *HighAvailability
+	host                         *Host
+	hostDevices                  *HostDeviceSlice
+	id                           *string
+	initialization               *Initialization
+	instanceType                 *InstanceType
+	io                           *Io
+	katelloErrata                *KatelloErratumSlice
+	largeIcon                    *Icon
+	lease                        *StorageDomainLease
+	memory                       *int64
+	memoryPolicy                 *MemoryPolicy
+	migration                    *MigrationOptions
+	migrationDowntime            *int64
+	multiQueuesEnabled           *bool
+	name                         *string
+	nextRunConfigurationExists   *bool
+	nics                         *NicSlice
+	numaNodes                    *NumaNodeSlice
+	numaTuneMode                 *NumaTuneMode
+	origin                       *string
+	originalTemplate             *Template
+	os                           *OperatingSystem
+	payloads                     *PayloadSlice
+	permissions                  *PermissionSlice
+	persistMemorystate           *bool
+	placementPolicy              *VmPlacementPolicy
+	quota                        *Quota
+	reportedDevices              *ReportedDeviceSlice
+	rngDevice                    *RngDevice
+	runOnce                      *bool
+	serialNumber                 *SerialNumber
+	sessions                     *SessionSlice
+	smallIcon                    *Icon
+	snapshotStatus               *SnapshotStatus
+	snapshotType                 *SnapshotType
+	snapshots                    *SnapshotSlice
+	soundcardEnabled             *bool
+	sso                          *Sso
+	startPaused                  *bool
+	startTime                    *time.Time
+	stateless                    *bool
+	statistics                   *StatisticSlice
+	status                       *VmStatus
+	statusDetail                 *string
+	stopReason                   *string
+	stopTime                     *time.Time
+	storageDomain                *StorageDomain
+	storageErrorResumeBehaviour  *VmStorageErrorResumeBehaviour
+	tags                         *TagSlice
+	template                     *Template
+	timeZone                     *TimeZone
+	tunnelMigration              *bool
+	type_                        *VmType
+	usb                          *Usb
+	useLatestTemplateVersion     *bool
+	virtioScsi                   *VirtioScsi
+	virtioScsiMultiQueuesEnabled *bool
+	vm                           *Vm
+	vmPool                       *VmPool
+	watchdogs                    *WatchdogSlice
 }
 
 func (p *Snapshot) SetAffinityLabels(attr *AffinityLabelSlice) {
@@ -30239,6 +30300,25 @@ func (p *Snapshot) MustVirtioScsi() *VirtioScsi {
 	return p.virtioScsi
 }
 
+func (p *Snapshot) SetVirtioScsiMultiQueuesEnabled(attr bool) {
+	p.virtioScsiMultiQueuesEnabled = &attr
+}
+
+func (p *Snapshot) VirtioScsiMultiQueuesEnabled() (bool, bool) {
+	if p.virtioScsiMultiQueuesEnabled != nil {
+		return *p.virtioScsiMultiQueuesEnabled, true
+	}
+	var zero bool
+	return zero, false
+}
+
+func (p *Snapshot) MustVirtioScsiMultiQueuesEnabled() bool {
+	if p.virtioScsiMultiQueuesEnabled == nil {
+		panic("the virtioScsiMultiQueuesEnabled must not be nil, please use VirtioScsiMultiQueuesEnabled() function instead")
+	}
+	return *p.virtioScsiMultiQueuesEnabled
+}
+
 func (p *Snapshot) SetVm(attr *Vm) {
 	p.vm = attr
 }
@@ -30388,6 +30468,7 @@ type Ssh struct {
 	id                   *string
 	name                 *string
 	port                 *int64
+	publicKey            *string
 	user                 *User
 }
 
@@ -30522,6 +30603,25 @@ func (p *Ssh) MustPort() int64 {
 		panic("the port must not be nil, please use Port() function instead")
 	}
 	return *p.port
+}
+
+func (p *Ssh) SetPublicKey(attr string) {
+	p.publicKey = &attr
+}
+
+func (p *Ssh) PublicKey() (string, bool) {
+	if p.publicKey != nil {
+		return *p.publicKey, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *Ssh) MustPublicKey() string {
+	if p.publicKey == nil {
+		panic("the publicKey must not be nil, please use PublicKey() function instead")
+	}
+	return *p.publicKey
 }
 
 func (p *Ssh) SetUser(attr *User) {
@@ -32928,62 +33028,63 @@ func (p *Tag) MustVm() *Vm {
 
 type Template struct {
 	Struct
-	bios                        *Bios
-	cdroms                      *CdromSlice
-	cluster                     *Cluster
-	comment                     *string
-	console                     *Console
-	cpu                         *Cpu
-	cpuProfile                  *CpuProfile
-	cpuShares                   *int64
-	creationTime                *time.Time
-	customCompatibilityVersion  *Version
-	customCpuModel              *string
-	customEmulatedMachine       *string
-	customProperties            *CustomPropertySlice
-	deleteProtected             *bool
-	description                 *string
-	diskAttachments             *DiskAttachmentSlice
-	display                     *Display
-	domain                      *Domain
-	graphicsConsoles            *GraphicsConsoleSlice
-	highAvailability            *HighAvailability
-	id                          *string
-	initialization              *Initialization
-	io                          *Io
-	largeIcon                   *Icon
-	lease                       *StorageDomainLease
-	memory                      *int64
-	memoryPolicy                *MemoryPolicy
-	migration                   *MigrationOptions
-	migrationDowntime           *int64
-	multiQueuesEnabled          *bool
-	name                        *string
-	nics                        *NicSlice
-	origin                      *string
-	os                          *OperatingSystem
-	permissions                 *PermissionSlice
-	placementPolicy             *VmPlacementPolicy
-	quota                       *Quota
-	rngDevice                   *RngDevice
-	serialNumber                *SerialNumber
-	smallIcon                   *Icon
-	soundcardEnabled            *bool
-	sso                         *Sso
-	startPaused                 *bool
-	stateless                   *bool
-	status                      *TemplateStatus
-	storageDomain               *StorageDomain
-	storageErrorResumeBehaviour *VmStorageErrorResumeBehaviour
-	tags                        *TagSlice
-	timeZone                    *TimeZone
-	tunnelMigration             *bool
-	type_                       *VmType
-	usb                         *Usb
-	version                     *TemplateVersion
-	virtioScsi                  *VirtioScsi
-	vm                          *Vm
-	watchdogs                   *WatchdogSlice
+	bios                         *Bios
+	cdroms                       *CdromSlice
+	cluster                      *Cluster
+	comment                      *string
+	console                      *Console
+	cpu                          *Cpu
+	cpuProfile                   *CpuProfile
+	cpuShares                    *int64
+	creationTime                 *time.Time
+	customCompatibilityVersion   *Version
+	customCpuModel               *string
+	customEmulatedMachine        *string
+	customProperties             *CustomPropertySlice
+	deleteProtected              *bool
+	description                  *string
+	diskAttachments              *DiskAttachmentSlice
+	display                      *Display
+	domain                       *Domain
+	graphicsConsoles             *GraphicsConsoleSlice
+	highAvailability             *HighAvailability
+	id                           *string
+	initialization               *Initialization
+	io                           *Io
+	largeIcon                    *Icon
+	lease                        *StorageDomainLease
+	memory                       *int64
+	memoryPolicy                 *MemoryPolicy
+	migration                    *MigrationOptions
+	migrationDowntime            *int64
+	multiQueuesEnabled           *bool
+	name                         *string
+	nics                         *NicSlice
+	origin                       *string
+	os                           *OperatingSystem
+	permissions                  *PermissionSlice
+	placementPolicy              *VmPlacementPolicy
+	quota                        *Quota
+	rngDevice                    *RngDevice
+	serialNumber                 *SerialNumber
+	smallIcon                    *Icon
+	soundcardEnabled             *bool
+	sso                          *Sso
+	startPaused                  *bool
+	stateless                    *bool
+	status                       *TemplateStatus
+	storageDomain                *StorageDomain
+	storageErrorResumeBehaviour  *VmStorageErrorResumeBehaviour
+	tags                         *TagSlice
+	timeZone                     *TimeZone
+	tunnelMigration              *bool
+	type_                        *VmType
+	usb                          *Usb
+	version                      *TemplateVersion
+	virtioScsi                   *VirtioScsi
+	virtioScsiMultiQueuesEnabled *bool
+	vm                           *Vm
+	watchdogs                    *WatchdogSlice
 }
 
 func (p *Template) SetBios(attr *Bios) {
@@ -33978,6 +34079,25 @@ func (p *Template) MustVirtioScsi() *VirtioScsi {
 	return p.virtioScsi
 }
 
+func (p *Template) SetVirtioScsiMultiQueuesEnabled(attr bool) {
+	p.virtioScsiMultiQueuesEnabled = &attr
+}
+
+func (p *Template) VirtioScsiMultiQueuesEnabled() (bool, bool) {
+	if p.virtioScsiMultiQueuesEnabled != nil {
+		return *p.virtioScsiMultiQueuesEnabled, true
+	}
+	var zero bool
+	return zero, false
+}
+
+func (p *Template) MustVirtioScsiMultiQueuesEnabled() bool {
+	if p.virtioScsiMultiQueuesEnabled == nil {
+		panic("the virtioScsiMultiQueuesEnabled must not be nil, please use VirtioScsiMultiQueuesEnabled() function instead")
+	}
+	return *p.virtioScsiMultiQueuesEnabled
+}
+
 func (p *Template) SetVm(attr *Vm) {
 	p.vm = attr
 }
@@ -34369,6 +34489,7 @@ type User struct {
 	loggedIn      *bool
 	name          *string
 	namespace     *string
+	options       *UserOptionSlice
 	password      *string
 	permissions   *PermissionSlice
 	principal     *string
@@ -34605,6 +34726,24 @@ func (p *User) MustNamespace() string {
 	return *p.namespace
 }
 
+func (p *User) SetOptions(attr *UserOptionSlice) {
+	p.options = attr
+}
+
+func (p *User) Options() (*UserOptionSlice, bool) {
+	if p.options != nil {
+		return p.options, true
+	}
+	return nil, false
+}
+
+func (p *User) MustOptions() *UserOptionSlice {
+	if p.options == nil {
+		panic("the options must not be nil, please use Options() function instead")
+	}
+	return p.options
+}
+
 func (p *User) SetPassword(attr string) {
 	p.password = &attr
 }
@@ -34750,6 +34889,129 @@ func (p *User) MustUserOptions() *PropertySlice {
 		panic("the userOptions must not be nil, please use UserOptions() function instead")
 	}
 	return p.userOptions
+}
+
+type UserOption struct {
+	Struct
+	comment     *string
+	content     *string
+	description *string
+	id          *string
+	name        *string
+	user        *User
+}
+
+func (p *UserOption) SetComment(attr string) {
+	p.comment = &attr
+}
+
+func (p *UserOption) Comment() (string, bool) {
+	if p.comment != nil {
+		return *p.comment, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *UserOption) MustComment() string {
+	if p.comment == nil {
+		panic("the comment must not be nil, please use Comment() function instead")
+	}
+	return *p.comment
+}
+
+func (p *UserOption) SetContent(attr string) {
+	p.content = &attr
+}
+
+func (p *UserOption) Content() (string, bool) {
+	if p.content != nil {
+		return *p.content, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *UserOption) MustContent() string {
+	if p.content == nil {
+		panic("the content must not be nil, please use Content() function instead")
+	}
+	return *p.content
+}
+
+func (p *UserOption) SetDescription(attr string) {
+	p.description = &attr
+}
+
+func (p *UserOption) Description() (string, bool) {
+	if p.description != nil {
+		return *p.description, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *UserOption) MustDescription() string {
+	if p.description == nil {
+		panic("the description must not be nil, please use Description() function instead")
+	}
+	return *p.description
+}
+
+func (p *UserOption) SetId(attr string) {
+	p.id = &attr
+}
+
+func (p *UserOption) Id() (string, bool) {
+	if p.id != nil {
+		return *p.id, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *UserOption) MustId() string {
+	if p.id == nil {
+		panic("the id must not be nil, please use Id() function instead")
+	}
+	return *p.id
+}
+
+func (p *UserOption) SetName(attr string) {
+	p.name = &attr
+}
+
+func (p *UserOption) Name() (string, bool) {
+	if p.name != nil {
+		return *p.name, true
+	}
+	var zero string
+	return zero, false
+}
+
+func (p *UserOption) MustName() string {
+	if p.name == nil {
+		panic("the name must not be nil, please use Name() function instead")
+	}
+	return *p.name
+}
+
+func (p *UserOption) SetUser(attr *User) {
+	p.user = attr
+}
+
+func (p *UserOption) User() (*User, bool) {
+	if p.user != nil {
+		return p.user, true
+	}
+	return nil, false
+}
+
+func (p *UserOption) MustUser() *User {
+	if p.user == nil {
+		panic("the user must not be nil, please use User() function instead")
+	}
+	return p.user
 }
 
 type Value struct {
@@ -35417,89 +35679,90 @@ func (p *Vlan) MustId() int64 {
 
 type Vm struct {
 	Struct
-	affinityLabels              *AffinityLabelSlice
-	applications                *ApplicationSlice
-	bios                        *Bios
-	cdroms                      *CdromSlice
-	cluster                     *Cluster
-	comment                     *string
-	console                     *Console
-	cpu                         *Cpu
-	cpuProfile                  *CpuProfile
-	cpuShares                   *int64
-	creationTime                *time.Time
-	customCompatibilityVersion  *Version
-	customCpuModel              *string
-	customEmulatedMachine       *string
-	customProperties            *CustomPropertySlice
-	deleteProtected             *bool
-	description                 *string
-	diskAttachments             *DiskAttachmentSlice
-	display                     *Display
-	domain                      *Domain
-	externalHostProvider        *ExternalHostProvider
-	floppies                    *FloppySlice
-	fqdn                        *string
-	graphicsConsoles            *GraphicsConsoleSlice
-	guestOperatingSystem        *GuestOperatingSystem
-	guestTimeZone               *TimeZone
-	hasIllegalImages            *bool
-	highAvailability            *HighAvailability
-	host                        *Host
-	hostDevices                 *HostDeviceSlice
-	id                          *string
-	initialization              *Initialization
-	instanceType                *InstanceType
-	io                          *Io
-	katelloErrata               *KatelloErratumSlice
-	largeIcon                   *Icon
-	lease                       *StorageDomainLease
-	memory                      *int64
-	memoryPolicy                *MemoryPolicy
-	migration                   *MigrationOptions
-	migrationDowntime           *int64
-	multiQueuesEnabled          *bool
-	name                        *string
-	nextRunConfigurationExists  *bool
-	nics                        *NicSlice
-	numaNodes                   *NumaNodeSlice
-	numaTuneMode                *NumaTuneMode
-	origin                      *string
-	originalTemplate            *Template
-	os                          *OperatingSystem
-	payloads                    *PayloadSlice
-	permissions                 *PermissionSlice
-	placementPolicy             *VmPlacementPolicy
-	quota                       *Quota
-	reportedDevices             *ReportedDeviceSlice
-	rngDevice                   *RngDevice
-	runOnce                     *bool
-	serialNumber                *SerialNumber
-	sessions                    *SessionSlice
-	smallIcon                   *Icon
-	snapshots                   *SnapshotSlice
-	soundcardEnabled            *bool
-	sso                         *Sso
-	startPaused                 *bool
-	startTime                   *time.Time
-	stateless                   *bool
-	statistics                  *StatisticSlice
-	status                      *VmStatus
-	statusDetail                *string
-	stopReason                  *string
-	stopTime                    *time.Time
-	storageDomain               *StorageDomain
-	storageErrorResumeBehaviour *VmStorageErrorResumeBehaviour
-	tags                        *TagSlice
-	template                    *Template
-	timeZone                    *TimeZone
-	tunnelMigration             *bool
-	type_                       *VmType
-	usb                         *Usb
-	useLatestTemplateVersion    *bool
-	virtioScsi                  *VirtioScsi
-	vmPool                      *VmPool
-	watchdogs                   *WatchdogSlice
+	affinityLabels               *AffinityLabelSlice
+	applications                 *ApplicationSlice
+	bios                         *Bios
+	cdroms                       *CdromSlice
+	cluster                      *Cluster
+	comment                      *string
+	console                      *Console
+	cpu                          *Cpu
+	cpuProfile                   *CpuProfile
+	cpuShares                    *int64
+	creationTime                 *time.Time
+	customCompatibilityVersion   *Version
+	customCpuModel               *string
+	customEmulatedMachine        *string
+	customProperties             *CustomPropertySlice
+	deleteProtected              *bool
+	description                  *string
+	diskAttachments              *DiskAttachmentSlice
+	display                      *Display
+	domain                       *Domain
+	externalHostProvider         *ExternalHostProvider
+	floppies                     *FloppySlice
+	fqdn                         *string
+	graphicsConsoles             *GraphicsConsoleSlice
+	guestOperatingSystem         *GuestOperatingSystem
+	guestTimeZone                *TimeZone
+	hasIllegalImages             *bool
+	highAvailability             *HighAvailability
+	host                         *Host
+	hostDevices                  *HostDeviceSlice
+	id                           *string
+	initialization               *Initialization
+	instanceType                 *InstanceType
+	io                           *Io
+	katelloErrata                *KatelloErratumSlice
+	largeIcon                    *Icon
+	lease                        *StorageDomainLease
+	memory                       *int64
+	memoryPolicy                 *MemoryPolicy
+	migration                    *MigrationOptions
+	migrationDowntime            *int64
+	multiQueuesEnabled           *bool
+	name                         *string
+	nextRunConfigurationExists   *bool
+	nics                         *NicSlice
+	numaNodes                    *NumaNodeSlice
+	numaTuneMode                 *NumaTuneMode
+	origin                       *string
+	originalTemplate             *Template
+	os                           *OperatingSystem
+	payloads                     *PayloadSlice
+	permissions                  *PermissionSlice
+	placementPolicy              *VmPlacementPolicy
+	quota                        *Quota
+	reportedDevices              *ReportedDeviceSlice
+	rngDevice                    *RngDevice
+	runOnce                      *bool
+	serialNumber                 *SerialNumber
+	sessions                     *SessionSlice
+	smallIcon                    *Icon
+	snapshots                    *SnapshotSlice
+	soundcardEnabled             *bool
+	sso                          *Sso
+	startPaused                  *bool
+	startTime                    *time.Time
+	stateless                    *bool
+	statistics                   *StatisticSlice
+	status                       *VmStatus
+	statusDetail                 *string
+	stopReason                   *string
+	stopTime                     *time.Time
+	storageDomain                *StorageDomain
+	storageErrorResumeBehaviour  *VmStorageErrorResumeBehaviour
+	tags                         *TagSlice
+	template                     *Template
+	timeZone                     *TimeZone
+	tunnelMigration              *bool
+	type_                        *VmType
+	usb                          *Usb
+	useLatestTemplateVersion     *bool
+	virtioScsi                   *VirtioScsi
+	virtioScsiMultiQueuesEnabled *bool
+	vmPool                       *VmPool
+	watchdogs                    *WatchdogSlice
 }
 
 func (p *Vm) SetAffinityLabels(attr *AffinityLabelSlice) {
@@ -36990,6 +37253,25 @@ func (p *Vm) MustVirtioScsi() *VirtioScsi {
 	return p.virtioScsi
 }
 
+func (p *Vm) SetVirtioScsiMultiQueuesEnabled(attr bool) {
+	p.virtioScsiMultiQueuesEnabled = &attr
+}
+
+func (p *Vm) VirtioScsiMultiQueuesEnabled() (bool, bool) {
+	if p.virtioScsiMultiQueuesEnabled != nil {
+		return *p.virtioScsiMultiQueuesEnabled, true
+	}
+	var zero bool
+	return zero, false
+}
+
+func (p *Vm) MustVirtioScsiMultiQueuesEnabled() bool {
+	if p.virtioScsiMultiQueuesEnabled == nil {
+		panic("the virtioScsiMultiQueuesEnabled must not be nil, please use VirtioScsiMultiQueuesEnabled() function instead")
+	}
+	return *p.virtioScsiMultiQueuesEnabled
+}
+
 func (p *Vm) SetVmPool(attr *VmPool) {
 	p.vmPool = attr
 }
@@ -37028,52 +37310,53 @@ func (p *Vm) MustWatchdogs() *WatchdogSlice {
 
 type VmBase struct {
 	Struct
-	bios                        *Bios
-	cluster                     *Cluster
-	comment                     *string
-	console                     *Console
-	cpu                         *Cpu
-	cpuProfile                  *CpuProfile
-	cpuShares                   *int64
-	creationTime                *time.Time
-	customCompatibilityVersion  *Version
-	customCpuModel              *string
-	customEmulatedMachine       *string
-	customProperties            *CustomPropertySlice
-	deleteProtected             *bool
-	description                 *string
-	display                     *Display
-	domain                      *Domain
-	highAvailability            *HighAvailability
-	id                          *string
-	initialization              *Initialization
-	io                          *Io
-	largeIcon                   *Icon
-	lease                       *StorageDomainLease
-	memory                      *int64
-	memoryPolicy                *MemoryPolicy
-	migration                   *MigrationOptions
-	migrationDowntime           *int64
-	multiQueuesEnabled          *bool
-	name                        *string
-	origin                      *string
-	os                          *OperatingSystem
-	placementPolicy             *VmPlacementPolicy
-	quota                       *Quota
-	rngDevice                   *RngDevice
-	serialNumber                *SerialNumber
-	smallIcon                   *Icon
-	soundcardEnabled            *bool
-	sso                         *Sso
-	startPaused                 *bool
-	stateless                   *bool
-	storageDomain               *StorageDomain
-	storageErrorResumeBehaviour *VmStorageErrorResumeBehaviour
-	timeZone                    *TimeZone
-	tunnelMigration             *bool
-	type_                       *VmType
-	usb                         *Usb
-	virtioScsi                  *VirtioScsi
+	bios                         *Bios
+	cluster                      *Cluster
+	comment                      *string
+	console                      *Console
+	cpu                          *Cpu
+	cpuProfile                   *CpuProfile
+	cpuShares                    *int64
+	creationTime                 *time.Time
+	customCompatibilityVersion   *Version
+	customCpuModel               *string
+	customEmulatedMachine        *string
+	customProperties             *CustomPropertySlice
+	deleteProtected              *bool
+	description                  *string
+	display                      *Display
+	domain                       *Domain
+	highAvailability             *HighAvailability
+	id                           *string
+	initialization               *Initialization
+	io                           *Io
+	largeIcon                    *Icon
+	lease                        *StorageDomainLease
+	memory                       *int64
+	memoryPolicy                 *MemoryPolicy
+	migration                    *MigrationOptions
+	migrationDowntime            *int64
+	multiQueuesEnabled           *bool
+	name                         *string
+	origin                       *string
+	os                           *OperatingSystem
+	placementPolicy              *VmPlacementPolicy
+	quota                        *Quota
+	rngDevice                    *RngDevice
+	serialNumber                 *SerialNumber
+	smallIcon                    *Icon
+	soundcardEnabled             *bool
+	sso                          *Sso
+	startPaused                  *bool
+	stateless                    *bool
+	storageDomain                *StorageDomain
+	storageErrorResumeBehaviour  *VmStorageErrorResumeBehaviour
+	timeZone                     *TimeZone
+	tunnelMigration              *bool
+	type_                        *VmType
+	usb                          *Usb
+	virtioScsi                   *VirtioScsi
+	virtioScsiMultiQueuesEnabled *bool
 }
 
 func (p *VmBase) SetBios(attr *Bios) {
@@ -37921,6 +38204,25 @@ func (p *VmBase) MustVirtioScsi() *VirtioScsi {
 		panic("the virtioScsi must not be nil, please use VirtioScsi() function instead")
 	}
 	return p.virtioScsi
+}
+
+func (p *VmBase) SetVirtioScsiMultiQueuesEnabled(attr bool) {
+	p.virtioScsiMultiQueuesEnabled = &attr
+}
+
+func (p *VmBase) VirtioScsiMultiQueuesEnabled() (bool, bool) {
+	if p.virtioScsiMultiQueuesEnabled != nil {
+		return *p.virtioScsiMultiQueuesEnabled, true
+	}
+	var zero bool
+	return zero, false
+}
+
+func (p *VmBase) MustVirtioScsiMultiQueuesEnabled() bool {
+	if p.virtioScsiMultiQueuesEnabled == nil {
+		panic("the virtioScsiMultiQueuesEnabled must not be nil, please use VirtioScsiMultiQueuesEnabled() function instead")
+	}
+	return *p.virtioScsiMultiQueuesEnabled
 }
 
 type VmPlacementPolicy struct {
@@ -39260,6 +39562,7 @@ type Action struct {
 	modifiedLabels                 *NetworkLabelSlice
 	modifiedNetworkAttachments     *NetworkAttachmentSlice
 	name                           *string
+	optimizeCpuSettings            *bool
 	option                         *Option
 	pause                          *bool
 	permission                     *Permission
@@ -40283,6 +40586,25 @@ func (p *Action) MustName() string {
 		panic("the name must not be nil, please use Name() function instead")
 	}
 	return *p.name
+}
+
+func (p *Action) SetOptimizeCpuSettings(attr bool) {
+	p.optimizeCpuSettings = &attr
+}
+
+func (p *Action) OptimizeCpuSettings() (bool, bool) {
+	if p.optimizeCpuSettings != nil {
+		return *p.optimizeCpuSettings, true
+	}
+	var zero bool
+	return zero, false
+}
+
+func (p *Action) MustOptimizeCpuSettings() bool {
+	if p.optimizeCpuSettings == nil {
+		panic("the optimizeCpuSettings must not be nil, please use OptimizeCpuSettings() function instead")
+	}
+	return *p.optimizeCpuSettings
 }
 
 func (p *Action) SetOption(attr *Option) {
@@ -44961,30 +45283,6 @@ func (op *SchedulingPolicySlice) SetSlice(slice []*SchedulingPolicy) {
 	op.slice = slice
 }
 
-type SeLinuxSlice struct {
-	href  *string
-	slice []*SeLinux
-}
-
-func (op *SeLinuxSlice) Href() (string, bool) {
-	if op.href == nil {
-		return "", false
-	}
-	return *op.href, true
-}
-
-func (op *SeLinuxSlice) SetHref(href string) {
-	op.href = &href
-}
-
-func (op *SeLinuxSlice) Slice() []*SeLinux {
-	return op.slice
-}
-
-func (op *SeLinuxSlice) SetSlice(slice []*SeLinux) {
-	op.slice = slice
-}
-
 type SchedulingPolicyUnitSlice struct {
 	href  *string
 	slice []*SchedulingPolicyUnit
@@ -45006,6 +45304,30 @@ func (op *SchedulingPolicyUnitSlice) Slice() []*SchedulingPolicyUnit {
 }
 
 func (op *SchedulingPolicyUnitSlice) SetSlice(slice []*SchedulingPolicyUnit) {
+	op.slice = slice
+}
+
+type SeLinuxSlice struct {
+	href  *string
+	slice []*SeLinux
+}
+
+func (op *SeLinuxSlice) Href() (string, bool) {
+	if op.href == nil {
+		return "", false
+	}
+	return *op.href, true
+}
+
+func (op *SeLinuxSlice) SetHref(href string) {
+	op.href = &href
+}
+
+func (op *SeLinuxSlice) Slice() []*SeLinux {
+	return op.slice
+}
+
+func (op *SeLinuxSlice) SetSlice(slice []*SeLinux) {
 	op.slice = slice
 }
 
@@ -45654,6 +45976,30 @@ func (op *UserSlice) Slice() []*User {
 }
 
 func (op *UserSlice) SetSlice(slice []*User) {
+	op.slice = slice
+}
+
+type UserOptionSlice struct {
+	href  *string
+	slice []*UserOption
+}
+
+func (op *UserOptionSlice) Href() (string, bool) {
+	if op.href == nil {
+		return "", false
+	}
+	return *op.href, true
+}
+
+func (op *UserOptionSlice) SetHref(href string) {
+	op.href = &href
+}
+
+func (op *UserOptionSlice) Slice() []*UserOption {
+	return op.slice
+}
+
+func (op *UserOptionSlice) SetSlice(slice []*UserOption) {
 	op.slice = slice
 }
 
@@ -49526,6 +49872,15 @@ func (builder *ClusterBuilder) FencingPolicyBuilder(attrBuilder *FencingPolicyBu
 		return builder
 	}
 	return builder.FencingPolicy(attr)
+}
+
+func (builder *ClusterBuilder) FipsMode(attr FipsMode) *ClusterBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.cluster.SetFipsMode(attr)
+	return builder
 }
 
 func (builder *ClusterBuilder) FirewallType(attr FirewallType) *ClusterBuilder {
@@ -62658,6 +63013,15 @@ func (builder *ImageTransferBuilder) SnapshotBuilder(attrBuilder *DiskSnapshotBu
 	return builder.Snapshot(attr)
 }
 
+func (builder *ImageTransferBuilder) TimeoutPolicy(attr ImageTransferTimeoutPolicy) *ImageTransferBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.imageTransfer.SetTimeoutPolicy(attr)
+	return builder
+}
+
 func (builder *ImageTransferBuilder) TransferUrl(attr string) *ImageTransferBuilder {
 	if builder.err != nil {
 		return builder
@@ -64171,6 +64535,15 @@ func (builder *InstanceTypeBuilder) VirtioScsiBuilder(attrBuilder *VirtioScsiBui
 		return builder
 	}
 	return builder.VirtioScsi(attr)
+}
+
+func (builder *InstanceTypeBuilder) VirtioScsiMultiQueuesEnabled(attr bool) *InstanceTypeBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.instanceType.SetVirtioScsiMultiQueuesEnabled(attr)
+	return builder
 }
 
 func (builder *InstanceTypeBuilder) Vm(attr *Vm) *InstanceTypeBuilder {
@@ -74608,47 +74981,6 @@ func (builder *SchedulingPolicyBuilder) MustBuild() *SchedulingPolicy {
 	return builder.schedulingPolicy
 }
 
-type SeLinuxBuilder struct {
-	seLinux *SeLinux
-	err     error
-}
-
-func NewSeLinuxBuilder() *SeLinuxBuilder {
-	return &SeLinuxBuilder{seLinux: &SeLinux{}, err: nil}
-}
-
-func (builder *SeLinuxBuilder) Mode(attr SeLinuxMode) *SeLinuxBuilder {
-	if builder.err != nil {
-		return builder
-	}
-
-	builder.seLinux.SetMode(attr)
-	return builder
-}
-
-func (builder *SeLinuxBuilder) Href(href string) *SeLinuxBuilder {
-	if builder.err != nil {
-		return builder
-	}
-
-	builder.seLinux.SetHref(href)
-	return builder
-}
-
-func (builder *SeLinuxBuilder) Build() (*SeLinux, error) {
-	if builder.err != nil {
-		return nil, builder.err
-	}
-	return builder.seLinux, nil
-}
-
-func (builder *SeLinuxBuilder) MustBuild() *SeLinux {
-	if builder.err != nil {
-		panic(fmt.Sprintf("Failed to build SeLinux instance, reason: %v", builder.err))
-	}
-	return builder.seLinux
-}
-
 type SchedulingPolicyUnitBuilder struct {
 	schedulingPolicyUnit *SchedulingPolicyUnit
 	err                  error
@@ -74783,6 +75115,47 @@ func (builder *SchedulingPolicyUnitBuilder) MustBuild() *SchedulingPolicyUnit {
 		panic(fmt.Sprintf("Failed to build SchedulingPolicyUnit instance, reason: %v", builder.err))
 	}
 	return builder.schedulingPolicyUnit
+}
+
+type SeLinuxBuilder struct {
+	seLinux *SeLinux
+	err     error
+}
+
+func NewSeLinuxBuilder() *SeLinuxBuilder {
+	return &SeLinuxBuilder{seLinux: &SeLinux{}, err: nil}
+}
+
+func (builder *SeLinuxBuilder) Mode(attr SeLinuxMode) *SeLinuxBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.seLinux.SetMode(attr)
+	return builder
+}
+
+func (builder *SeLinuxBuilder) Href(href string) *SeLinuxBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.seLinux.SetHref(href)
+	return builder
+}
+
+func (builder *SeLinuxBuilder) Build() (*SeLinux, error) {
+	if builder.err != nil {
+		return nil, builder.err
+	}
+	return builder.seLinux, nil
+}
+
+func (builder *SeLinuxBuilder) MustBuild() *SeLinux {
+	if builder.err != nil {
+		panic(fmt.Sprintf("Failed to build SeLinux instance, reason: %v", builder.err))
+	}
+	return builder.seLinux
 }
 
 type SerialNumberBuilder struct {
@@ -77042,6 +77415,15 @@ func (builder *SnapshotBuilder) VirtioScsiBuilder(attrBuilder *VirtioScsiBuilder
 	return builder.VirtioScsi(attr)
 }
 
+func (builder *SnapshotBuilder) VirtioScsiMultiQueuesEnabled(attr bool) *SnapshotBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.snapshot.SetVirtioScsiMultiQueuesEnabled(attr)
+	return builder
+}
+
 func (builder *SnapshotBuilder) Vm(attr *Vm) *SnapshotBuilder {
 	if builder.err != nil {
 		return builder
@@ -77361,6 +77743,15 @@ func (builder *SshBuilder) Port(attr int64) *SshBuilder {
 	}
 
 	builder.ssh.SetPort(attr)
+	return builder
+}
+
+func (builder *SshBuilder) PublicKey(attr string) *SshBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.ssh.SetPublicKey(attr)
 	return builder
 }
 
@@ -80904,6 +81295,15 @@ func (builder *TemplateBuilder) VirtioScsiBuilder(attrBuilder *VirtioScsiBuilder
 	return builder.VirtioScsi(attr)
 }
 
+func (builder *TemplateBuilder) VirtioScsiMultiQueuesEnabled(attr bool) *TemplateBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.template.SetVirtioScsiMultiQueuesEnabled(attr)
+	return builder
+}
+
 func (builder *TemplateBuilder) Vm(attr *Vm) *TemplateBuilder {
 	if builder.err != nil {
 		return builder
@@ -81547,6 +81947,47 @@ func (builder *UserBuilder) Namespace(attr string) *UserBuilder {
 	return builder
 }
 
+func (builder *UserBuilder) Options(attr *UserOptionSlice) *UserBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.user.SetOptions(attr)
+	return builder
+}
+
+func (builder *UserBuilder) OptionsOfAny(anys ...*UserOption) *UserBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	if builder.user.options == nil {
+		builder.user.options = new(UserOptionSlice)
+	}
+	builder.user.options.slice = append(builder.user.options.slice, anys...)
+	return builder
+}
+
+func (builder *UserBuilder) OptionsBuilderOfAny(anyBuilders ...UserOptionBuilder) *UserBuilder {
+	if builder.err != nil || len(anyBuilders) == 0 {
+		return builder
+	}
+
+	for _, b := range anyBuilders {
+		if b.err != nil {
+			builder.err = b.err
+			return builder
+		}
+		attr, err := b.Build()
+		if err != nil {
+			builder.err = b.err
+			return builder
+		}
+		builder.OptionsOfAny(attr)
+	}
+	return builder
+}
+
 func (builder *UserBuilder) Password(attr string) *UserBuilder {
 	if builder.err != nil {
 		return builder
@@ -81800,6 +82241,109 @@ func (builder *UserBuilder) MustBuild() *User {
 		panic(fmt.Sprintf("Failed to build User instance, reason: %v", builder.err))
 	}
 	return builder.user
+}
+
+type UserOptionBuilder struct {
+	userOption *UserOption
+	err        error
+}
+
+func NewUserOptionBuilder() *UserOptionBuilder {
+	return &UserOptionBuilder{userOption: &UserOption{}, err: nil}
+}
+
+func (builder *UserOptionBuilder) Comment(attr string) *UserOptionBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.userOption.SetComment(attr)
+	return builder
+}
+
+func (builder *UserOptionBuilder) Content(attr string) *UserOptionBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.userOption.SetContent(attr)
+	return builder
+}
+
+func (builder *UserOptionBuilder) Description(attr string) *UserOptionBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.userOption.SetDescription(attr)
+	return builder
+}
+
+func (builder *UserOptionBuilder) Id(attr string) *UserOptionBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.userOption.SetId(attr)
+	return builder
+}
+
+func (builder *UserOptionBuilder) Name(attr string) *UserOptionBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.userOption.SetName(attr)
+	return builder
+}
+
+func (builder *UserOptionBuilder) User(attr *User) *UserOptionBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.userOption.SetUser(attr)
+	return builder
+}
+
+func (builder *UserOptionBuilder) UserBuilder(attrBuilder *UserBuilder) *UserOptionBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	if attrBuilder.err != nil {
+		builder.err = attrBuilder.err
+		return builder
+	}
+	attr, err := attrBuilder.Build()
+	if err != nil {
+		builder.err = err
+		return builder
+	}
+	return builder.User(attr)
+}
+
+func (builder *UserOptionBuilder) Href(href string) *UserOptionBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.userOption.SetHref(href)
+	return builder
+}
+
+func (builder *UserOptionBuilder) Build() (*UserOption, error) {
+	if builder.err != nil {
+		return nil, builder.err
+	}
+	return builder.userOption, nil
+}
+
+func (builder *UserOptionBuilder) MustBuild() *UserOption {
+	if builder.err != nil {
+		panic(fmt.Sprintf("Failed to build UserOption instance, reason: %v", builder.err))
+	}
+	return builder.userOption
 }
 
 type ValueBuilder struct {
@@ -84304,6 +84848,15 @@ func (builder *VmBuilder) VirtioScsiBuilder(attrBuilder *VirtioScsiBuilder) *VmB
 	return builder.VirtioScsi(attr)
 }
 
+func (builder *VmBuilder) VirtioScsiMultiQueuesEnabled(attr bool) *VmBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.vm.SetVirtioScsiMultiQueuesEnabled(attr)
+	return builder
+}
+
 func (builder *VmBuilder) VmPool(attr *VmPool) *VmBuilder {
 	if builder.err != nil {
 		return builder
@@ -85289,6 +85842,15 @@ func (builder *VmBaseBuilder) VirtioScsiBuilder(attrBuilder *VirtioScsiBuilder) 
 		return builder
 	}
 	return builder.VirtioScsi(attr)
+}
+
+func (builder *VmBaseBuilder) VirtioScsiMultiQueuesEnabled(attr bool) *VmBaseBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.vmBase.SetVirtioScsiMultiQueuesEnabled(attr)
+	return builder
 }
 
 func (builder *VmBaseBuilder) Href(href string) *VmBaseBuilder {
@@ -87703,6 +88265,15 @@ func (builder *ActionBuilder) Name(attr string) *ActionBuilder {
 	return builder
 }
 
+func (builder *ActionBuilder) OptimizeCpuSettings(attr bool) *ActionBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.action.SetOptimizeCpuSettings(attr)
+	return builder
+}
+
 func (builder *ActionBuilder) Option(attr *Option) *ActionBuilder {
 	if builder.err != nil {
 		return builder
@@ -88780,6 +89351,14 @@ const (
 	FENCETYPE_STOP    FenceType = "stop"
 )
 
+type FipsMode string
+
+const (
+	FIPSMODE_DISABLED  FipsMode = "disabled"
+	FIPSMODE_ENABLED   FipsMode = "enabled"
+	FIPSMODE_UNDEFINED FipsMode = "undefined"
+)
+
 type FirewallType string
 
 const (
@@ -88907,6 +89486,14 @@ const (
 	IMAGETRANSFERPHASE_RESUMING           ImageTransferPhase = "resuming"
 	IMAGETRANSFERPHASE_TRANSFERRING       ImageTransferPhase = "transferring"
 	IMAGETRANSFERPHASE_UNKNOWN            ImageTransferPhase = "unknown"
+)
+
+type ImageTransferTimeoutPolicy string
+
+const (
+	IMAGETRANSFERTIMEOUTPOLICY_CANCEL ImageTransferTimeoutPolicy = "cancel"
+	IMAGETRANSFERTIMEOUTPOLICY_LEGACY ImageTransferTimeoutPolicy = "legacy"
+	IMAGETRANSFERTIMEOUTPOLICY_PAUSE  ImageTransferTimeoutPolicy = "pause"
 )
 
 type InheritableBoolean string

--- a/vendor/github.com/ovirt/go-ovirt/writers.go
+++ b/vendor/github.com/ovirt/go-ovirt/writers.go
@@ -1137,6 +1137,9 @@ func XMLClusterWriteOne(writer *XMLWriter, object *Cluster, tag string) error {
 	if r, ok := object.FencingPolicy(); ok {
 		XMLFencingPolicyWriteOne(writer, r, "fencing_policy")
 	}
+	if r, ok := object.FipsMode(); ok {
+		XMLFipsModeWriteOne(writer, r, "fips_mode")
+	}
 	if r, ok := object.FirewallType(); ok {
 		XMLFirewallTypeWriteOne(writer, r, "firewall_type")
 	}
@@ -5038,6 +5041,9 @@ func XMLImageTransferWriteOne(writer *XMLWriter, object *ImageTransfer, tag stri
 	if r, ok := object.Snapshot(); ok {
 		XMLDiskSnapshotWriteOne(writer, r, "snapshot")
 	}
+	if r, ok := object.TimeoutPolicy(); ok {
+		XMLImageTransferTimeoutPolicyWriteOne(writer, r, "timeout_policy")
+	}
 	if r, ok := object.TransferUrl(); ok {
 		writer.WriteCharacter("transfer_url", r)
 	}
@@ -5329,6 +5335,9 @@ func XMLInstanceTypeWriteOne(writer *XMLWriter, object *InstanceType, tag string
 	}
 	if r, ok := object.VirtioScsi(); ok {
 		XMLVirtioScsiWriteOne(writer, r, "virtio_scsi")
+	}
+	if r, ok := object.VirtioScsiMultiQueuesEnabled(); ok {
+		writer.WriteBool("virtio_scsi_multi_queues_enabled", r)
 	}
 	if r, ok := object.Vm(); ok {
 		XMLVmWriteOne(writer, r, "vm")
@@ -8981,36 +8990,6 @@ func XMLSchedulingPolicyWriteMany(writer *XMLWriter, structSlice *SchedulingPoli
 	return nil
 }
 
-func XMLSeLinuxWriteOne(writer *XMLWriter, object *SeLinux, tag string) error {
-	if object == nil {
-		return fmt.Errorf("input object pointer is nil")
-	}
-	if tag == "" {
-		tag = "se_linux"
-	}
-	writer.WriteStart("", tag, nil)
-	if r, ok := object.Mode(); ok {
-		XMLSeLinuxModeWriteOne(writer, r, "mode")
-	}
-	writer.WriteEnd(tag)
-	return nil
-}
-
-func XMLSeLinuxWriteMany(writer *XMLWriter, structSlice *SeLinuxSlice, plural, singular string) error {
-	if plural == "" {
-		plural = "se_linuxs"
-	}
-	if singular == "" {
-		singular = "se_linux"
-	}
-	writer.WriteStart("", plural, nil)
-	for _, o := range structSlice.Slice() {
-		XMLSeLinuxWriteOne(writer, o, singular)
-	}
-	writer.WriteEnd(plural)
-	return nil
-}
-
 func XMLSchedulingPolicyUnitWriteOne(writer *XMLWriter, object *SchedulingPolicyUnit, tag string) error {
 	if object == nil {
 		return fmt.Errorf("input object pointer is nil")
@@ -9061,6 +9040,36 @@ func XMLSchedulingPolicyUnitWriteMany(writer *XMLWriter, structSlice *Scheduling
 	writer.WriteStart("", plural, nil)
 	for _, o := range structSlice.Slice() {
 		XMLSchedulingPolicyUnitWriteOne(writer, o, singular)
+	}
+	writer.WriteEnd(plural)
+	return nil
+}
+
+func XMLSeLinuxWriteOne(writer *XMLWriter, object *SeLinux, tag string) error {
+	if object == nil {
+		return fmt.Errorf("input object pointer is nil")
+	}
+	if tag == "" {
+		tag = "se_linux"
+	}
+	writer.WriteStart("", tag, nil)
+	if r, ok := object.Mode(); ok {
+		XMLSeLinuxModeWriteOne(writer, r, "mode")
+	}
+	writer.WriteEnd(tag)
+	return nil
+}
+
+func XMLSeLinuxWriteMany(writer *XMLWriter, structSlice *SeLinuxSlice, plural, singular string) error {
+	if plural == "" {
+		plural = "se_linuxs"
+	}
+	if singular == "" {
+		singular = "se_linux"
+	}
+	writer.WriteStart("", plural, nil)
+	for _, o := range structSlice.Slice() {
+		XMLSeLinuxWriteOne(writer, o, singular)
 	}
 	writer.WriteEnd(plural)
 	return nil
@@ -9490,6 +9499,9 @@ func XMLSnapshotWriteOne(writer *XMLWriter, object *Snapshot, tag string) error 
 	if r, ok := object.VirtioScsi(); ok {
 		XMLVirtioScsiWriteOne(writer, r, "virtio_scsi")
 	}
+	if r, ok := object.VirtioScsiMultiQueuesEnabled(); ok {
+		writer.WriteBool("virtio_scsi_multi_queues_enabled", r)
+	}
 	if r, ok := object.Vm(); ok {
 		XMLVmWriteOne(writer, r, "vm")
 	}
@@ -9616,6 +9628,9 @@ func XMLSshWriteOne(writer *XMLWriter, object *Ssh, tag string) error {
 	}
 	if r, ok := object.Port(); ok {
 		writer.WriteInt64("port", r)
+	}
+	if r, ok := object.PublicKey(); ok {
+		writer.WriteCharacter("public_key", r)
 	}
 	if r, ok := object.User(); ok {
 		XMLUserWriteOne(writer, r, "user")
@@ -10499,6 +10514,9 @@ func XMLTemplateWriteOne(writer *XMLWriter, object *Template, tag string) error 
 	if r, ok := object.VirtioScsi(); ok {
 		XMLVirtioScsiWriteOne(writer, r, "virtio_scsi")
 	}
+	if r, ok := object.VirtioScsiMultiQueuesEnabled(); ok {
+		writer.WriteBool("virtio_scsi_multi_queues_enabled", r)
+	}
 	if r, ok := object.Vm(); ok {
 		XMLVmWriteOne(writer, r, "vm")
 	}
@@ -10786,6 +10804,9 @@ func XMLUserWriteOne(writer *XMLWriter, object *User, tag string) error {
 	if r, ok := object.Namespace(); ok {
 		writer.WriteCharacter("namespace", r)
 	}
+	if r, ok := object.Options(); ok {
+		XMLUserOptionWriteMany(writer, r, "options", "user_option")
+	}
 	if r, ok := object.Password(); ok {
 		writer.WriteCharacter("password", r)
 	}
@@ -10824,6 +10845,55 @@ func XMLUserWriteMany(writer *XMLWriter, structSlice *UserSlice, plural, singula
 	writer.WriteStart("", plural, nil)
 	for _, o := range structSlice.Slice() {
 		XMLUserWriteOne(writer, o, singular)
+	}
+	writer.WriteEnd(plural)
+	return nil
+}
+
+func XMLUserOptionWriteOne(writer *XMLWriter, object *UserOption, tag string) error {
+	if object == nil {
+		return fmt.Errorf("input object pointer is nil")
+	}
+	if tag == "" {
+		tag = "user_option"
+	}
+	var attrs map[string]string
+	if r, ok := object.Id(); ok {
+		if attrs == nil {
+			attrs = make(map[string]string)
+		}
+		attrs["id"] = r
+	}
+	writer.WriteStart("", tag, attrs)
+	if r, ok := object.Comment(); ok {
+		writer.WriteCharacter("comment", r)
+	}
+	if r, ok := object.Content(); ok {
+		writer.WriteCharacter("content", r)
+	}
+	if r, ok := object.Description(); ok {
+		writer.WriteCharacter("description", r)
+	}
+	if r, ok := object.Name(); ok {
+		writer.WriteCharacter("name", r)
+	}
+	if r, ok := object.User(); ok {
+		XMLUserWriteOne(writer, r, "user")
+	}
+	writer.WriteEnd(tag)
+	return nil
+}
+
+func XMLUserOptionWriteMany(writer *XMLWriter, structSlice *UserOptionSlice, plural, singular string) error {
+	if plural == "" {
+		plural = "user_options"
+	}
+	if singular == "" {
+		singular = "user_option"
+	}
+	writer.WriteStart("", plural, nil)
+	for _, o := range structSlice.Slice() {
+		XMLUserOptionWriteOne(writer, o, singular)
 	}
 	writer.WriteEnd(plural)
 	return nil
@@ -11385,6 +11455,9 @@ func XMLVmWriteOne(writer *XMLWriter, object *Vm, tag string) error {
 	if r, ok := object.VirtioScsi(); ok {
 		XMLVirtioScsiWriteOne(writer, r, "virtio_scsi")
 	}
+	if r, ok := object.VirtioScsiMultiQueuesEnabled(); ok {
+		writer.WriteBool("virtio_scsi_multi_queues_enabled", r)
+	}
 	if r, ok := object.VmPool(); ok {
 		XMLVmPoolWriteOne(writer, r, "vm_pool")
 	}
@@ -11559,6 +11632,9 @@ func XMLVmBaseWriteOne(writer *XMLWriter, object *VmBase, tag string) error {
 	}
 	if r, ok := object.VirtioScsi(); ok {
 		XMLVirtioScsiWriteOne(writer, r, "virtio_scsi")
+	}
+	if r, ok := object.VirtioScsiMultiQueuesEnabled(); ok {
+		writer.WriteBool("virtio_scsi_multi_queues_enabled", r)
 	}
 	writer.WriteEnd(tag)
 	return nil
@@ -12255,6 +12331,9 @@ func XMLActionWriteOne(writer *XMLWriter, object *Action, tag string) error {
 	}
 	if r, ok := object.Name(); ok {
 		writer.WriteCharacter("name", r)
+	}
+	if r, ok := object.OptimizeCpuSettings(); ok {
+		writer.WriteBool("optimize_cpu_settings", r)
 	}
 	if r, ok := object.Option(); ok {
 		XMLOptionWriteOne(writer, r, "option")
@@ -13077,6 +13156,28 @@ func XMLFenceTypeWriteMany(writer *XMLWriter, enums []FenceType, plural, singula
 	return nil
 }
 
+func XMLFipsModeWriteOne(writer *XMLWriter, enum FipsMode, tag string) {
+	if tag == "" {
+		tag = "fips_mode"
+	}
+	writer.WriteCharacter(tag, string(enum))
+}
+
+func XMLFipsModeWriteMany(writer *XMLWriter, enums []FipsMode, plural, singular string) error {
+	if plural == "" {
+		plural = "fips_modes"
+	}
+	if singular == "" {
+		singular = "fips_mode"
+	}
+	writer.WriteStart("", plural, nil)
+	for _, e := range enums {
+		writer.WriteCharacter(singular, string(e))
+	}
+	writer.WriteEnd(plural)
+	return nil
+}
+
 func XMLFirewallTypeWriteOne(writer *XMLWriter, enum FirewallType, tag string) {
 	if tag == "" {
 		tag = "firewall_type"
@@ -13354,6 +13455,28 @@ func XMLImageTransferPhaseWriteMany(writer *XMLWriter, enums []ImageTransferPhas
 	}
 	if singular == "" {
 		singular = "image_transfer_phase"
+	}
+	writer.WriteStart("", plural, nil)
+	for _, e := range enums {
+		writer.WriteCharacter(singular, string(e))
+	}
+	writer.WriteEnd(plural)
+	return nil
+}
+
+func XMLImageTransferTimeoutPolicyWriteOne(writer *XMLWriter, enum ImageTransferTimeoutPolicy, tag string) {
+	if tag == "" {
+		tag = "image_transfer_timeout_policy"
+	}
+	writer.WriteCharacter(tag, string(enum))
+}
+
+func XMLImageTransferTimeoutPolicyWriteMany(writer *XMLWriter, enums []ImageTransferTimeoutPolicy, plural, singular string) error {
+	if plural == "" {
+		plural = "image_transfer_timeout_policies"
+	}
+	if singular == "" {
+		singular = "image_transfer_timeout_policy"
 	}
 	writer.WriteStart("", plural, nil)
 	for _, e := range enums {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,11 +1,11 @@
 # cloud.google.com/go v0.45.1
-cloud.google.com/go/compute/metadata
+cloud.google.com/go/storage
 cloud.google.com/go/iam
 cloud.google.com/go/internal
 cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
-cloud.google.com/go/storage
+cloud.google.com/go/compute/metadata
 # github.com/agext/levenshtein v1.2.2
 github.com/agext/levenshtein
 # github.com/apparentlymart/go-cidr v1.0.1
@@ -16,42 +16,42 @@ github.com/apparentlymart/go-textseg/textseg
 github.com/armon/go-radix
 # github.com/aws/aws-sdk-go v1.25.3
 github.com/aws/aws-sdk-go/aws
-github.com/aws/aws-sdk-go/aws/awserr
-github.com/aws/aws-sdk-go/aws/awsutil
-github.com/aws/aws-sdk-go/aws/client
-github.com/aws/aws-sdk-go/aws/client/metadata
-github.com/aws/aws-sdk-go/aws/corehandlers
 github.com/aws/aws-sdk-go/aws/credentials
 github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds
-github.com/aws/aws-sdk-go/aws/credentials/endpointcreds
+github.com/aws/aws-sdk-go/aws/ec2metadata
+github.com/aws/aws-sdk-go/aws/session
+github.com/aws/aws-sdk-go/service/s3
+github.com/aws/aws-sdk-go/aws/awserr
+github.com/aws/aws-sdk-go/aws/endpoints
+github.com/aws/aws-sdk-go/internal/sdkio
+github.com/aws/aws-sdk-go/internal/ini
+github.com/aws/aws-sdk-go/internal/shareddefaults
+github.com/aws/aws-sdk-go/aws/client
+github.com/aws/aws-sdk-go/aws/request
+github.com/aws/aws-sdk-go/internal/sdkuri
+github.com/aws/aws-sdk-go/aws/client/metadata
+github.com/aws/aws-sdk-go/aws/corehandlers
 github.com/aws/aws-sdk-go/aws/credentials/processcreds
 github.com/aws/aws-sdk-go/aws/credentials/stscreds
 github.com/aws/aws-sdk-go/aws/csm
 github.com/aws/aws-sdk-go/aws/defaults
-github.com/aws/aws-sdk-go/aws/ec2metadata
-github.com/aws/aws-sdk-go/aws/endpoints
-github.com/aws/aws-sdk-go/aws/request
-github.com/aws/aws-sdk-go/aws/session
+github.com/aws/aws-sdk-go/aws/awsutil
 github.com/aws/aws-sdk-go/aws/signer/v4
-github.com/aws/aws-sdk-go/internal/ini
 github.com/aws/aws-sdk-go/internal/s3err
-github.com/aws/aws-sdk-go/internal/sdkio
-github.com/aws/aws-sdk-go/internal/sdkmath
-github.com/aws/aws-sdk-go/internal/sdkrand
-github.com/aws/aws-sdk-go/internal/sdkuri
-github.com/aws/aws-sdk-go/internal/shareddefaults
 github.com/aws/aws-sdk-go/private/protocol
 github.com/aws/aws-sdk-go/private/protocol/eventstream
 github.com/aws/aws-sdk-go/private/protocol/eventstream/eventstreamapi
-github.com/aws/aws-sdk-go/private/protocol/json/jsonutil
-github.com/aws/aws-sdk-go/private/protocol/query
-github.com/aws/aws-sdk-go/private/protocol/query/queryutil
 github.com/aws/aws-sdk-go/private/protocol/rest
 github.com/aws/aws-sdk-go/private/protocol/restxml
 github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil
-github.com/aws/aws-sdk-go/service/s3
+github.com/aws/aws-sdk-go/internal/sdkrand
 github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
+github.com/aws/aws-sdk-go/aws/credentials/endpointcreds
+github.com/aws/aws-sdk-go/internal/sdkmath
+github.com/aws/aws-sdk-go/private/protocol/query
+github.com/aws/aws-sdk-go/private/protocol/json/jsonutil
+github.com/aws/aws-sdk-go/private/protocol/query/queryutil
 # github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 github.com/bgentry/go-netrc/netrc
 # github.com/bgentry/speakeasy v0.1.0
@@ -62,11 +62,11 @@ github.com/davecgh/go-spew/spew
 github.com/fatih/color
 # github.com/golang/protobuf v1.3.2
 github.com/golang/protobuf/proto
-github.com/golang/protobuf/protoc-gen-go/descriptor
 github.com/golang/protobuf/ptypes
 github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
+github.com/golang/protobuf/protoc-gen-go/descriptor
 # github.com/google/go-cmp v0.3.1
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
@@ -103,24 +103,24 @@ github.com/hashicorp/golang-lru/simplelru
 github.com/hashicorp/hcl
 github.com/hashicorp/hcl/hcl/ast
 github.com/hashicorp/hcl/hcl/parser
-github.com/hashicorp/hcl/hcl/scanner
-github.com/hashicorp/hcl/hcl/strconv
 github.com/hashicorp/hcl/hcl/token
 github.com/hashicorp/hcl/json/parser
+github.com/hashicorp/hcl/hcl/scanner
+github.com/hashicorp/hcl/hcl/strconv
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
 # github.com/hashicorp/hcl/v2 v2.3.0
 github.com/hashicorp/hcl/v2
-github.com/hashicorp/hcl/v2/ext/customdecode
-github.com/hashicorp/hcl/v2/ext/dynblock
-github.com/hashicorp/hcl/v2/ext/typeexpr
-github.com/hashicorp/hcl/v2/gohcl
+github.com/hashicorp/hcl/v2/hclsyntax
 github.com/hashicorp/hcl/v2/hcldec
+github.com/hashicorp/hcl/v2/ext/customdecode
 github.com/hashicorp/hcl/v2/hcled
 github.com/hashicorp/hcl/v2/hclparse
-github.com/hashicorp/hcl/v2/hclsyntax
-github.com/hashicorp/hcl/v2/hclwrite
+github.com/hashicorp/hcl/v2/ext/typeexpr
+github.com/hashicorp/hcl/v2/gohcl
+github.com/hashicorp/hcl/v2/ext/dynblock
 github.com/hashicorp/hcl/v2/json
+github.com/hashicorp/hcl/v2/hclwrite
 # github.com/hashicorp/logutils v1.0.0
 github.com/hashicorp/logutils
 # github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7
@@ -128,56 +128,56 @@ github.com/hashicorp/terraform-config-inspect/tfconfig
 # github.com/hashicorp/terraform-json v0.4.0
 github.com/hashicorp/terraform-json
 # github.com/hashicorp/terraform-plugin-sdk v1.8.0
-github.com/hashicorp/terraform-plugin-sdk/acctest
-github.com/hashicorp/terraform-plugin-sdk/helper/hashcode
-github.com/hashicorp/terraform-plugin-sdk/helper/logging
+github.com/hashicorp/terraform-plugin-sdk/plugin
 github.com/hashicorp/terraform-plugin-sdk/helper/resource
 github.com/hashicorp/terraform-plugin-sdk/helper/schema
-github.com/hashicorp/terraform-plugin-sdk/helper/structure
 github.com/hashicorp/terraform-plugin-sdk/helper/validation
-github.com/hashicorp/terraform-plugin-sdk/httpclient
-github.com/hashicorp/terraform-plugin-sdk/internal/addrs
-github.com/hashicorp/terraform-plugin-sdk/internal/command/format
-github.com/hashicorp/terraform-plugin-sdk/internal/configs
-github.com/hashicorp/terraform-plugin-sdk/internal/configs/configload
+github.com/hashicorp/terraform-plugin-sdk/terraform
 github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema
-github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim
-github.com/hashicorp/terraform-plugin-sdk/internal/dag
-github.com/hashicorp/terraform-plugin-sdk/internal/earlyconfig
-github.com/hashicorp/terraform-plugin-sdk/internal/flatmap
-github.com/hashicorp/terraform-plugin-sdk/internal/helper/config
-github.com/hashicorp/terraform-plugin-sdk/internal/helper/didyoumean
 github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin
-github.com/hashicorp/terraform-plugin-sdk/internal/httpclient
-github.com/hashicorp/terraform-plugin-sdk/internal/initwd
-github.com/hashicorp/terraform-plugin-sdk/internal/lang
-github.com/hashicorp/terraform-plugin-sdk/internal/lang/blocktoattr
-github.com/hashicorp/terraform-plugin-sdk/internal/lang/funcs
-github.com/hashicorp/terraform-plugin-sdk/internal/modsdir
-github.com/hashicorp/terraform-plugin-sdk/internal/moduledeps
-github.com/hashicorp/terraform-plugin-sdk/internal/plans
-github.com/hashicorp/terraform-plugin-sdk/internal/plans/objchange
 github.com/hashicorp/terraform-plugin-sdk/internal/plugin/convert
 github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery
 github.com/hashicorp/terraform-plugin-sdk/internal/providers
 github.com/hashicorp/terraform-plugin-sdk/internal/provisioners
+github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5
+github.com/hashicorp/terraform-plugin-sdk/acctest
+github.com/hashicorp/terraform-plugin-sdk/helper/logging
+github.com/hashicorp/terraform-plugin-sdk/internal/addrs
+github.com/hashicorp/terraform-plugin-sdk/internal/command/format
+github.com/hashicorp/terraform-plugin-sdk/internal/configs
+github.com/hashicorp/terraform-plugin-sdk/internal/configs/configload
+github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim
+github.com/hashicorp/terraform-plugin-sdk/internal/helper/config
+github.com/hashicorp/terraform-plugin-sdk/internal/initwd
+github.com/hashicorp/terraform-plugin-sdk/internal/plans
+github.com/hashicorp/terraform-plugin-sdk/internal/states
+github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags
+github.com/hashicorp/terraform-plugin-sdk/helper/hashcode
+github.com/hashicorp/terraform-plugin-sdk/helper/structure
+github.com/hashicorp/terraform-plugin-sdk/internal/dag
+github.com/hashicorp/terraform-plugin-sdk/internal/helper/didyoumean
+github.com/hashicorp/terraform-plugin-sdk/internal/lang
+github.com/hashicorp/terraform-plugin-sdk/internal/moduledeps
+github.com/hashicorp/terraform-plugin-sdk/internal/plans/objchange
+github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile
+github.com/hashicorp/terraform-plugin-sdk/internal/version
+github.com/hashicorp/terraform-plugin-sdk/internal/httpclient
 github.com/hashicorp/terraform-plugin-sdk/internal/registry
 github.com/hashicorp/terraform-plugin-sdk/internal/registry/regsrc
 github.com/hashicorp/terraform-plugin-sdk/internal/registry/response
-github.com/hashicorp/terraform-plugin-sdk/internal/states
-github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile
-github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags
-github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5
-github.com/hashicorp/terraform-plugin-sdk/internal/version
+github.com/hashicorp/terraform-plugin-sdk/internal/modsdir
+github.com/hashicorp/terraform-plugin-sdk/internal/flatmap
+github.com/hashicorp/terraform-plugin-sdk/internal/earlyconfig
+github.com/hashicorp/terraform-plugin-sdk/internal/lang/blocktoattr
+github.com/hashicorp/terraform-plugin-sdk/internal/lang/funcs
+github.com/hashicorp/terraform-plugin-sdk/httpclient
 github.com/hashicorp/terraform-plugin-sdk/meta
-github.com/hashicorp/terraform-plugin-sdk/plugin
-github.com/hashicorp/terraform-plugin-sdk/terraform
 # github.com/hashicorp/terraform-plugin-test v1.2.0
 github.com/hashicorp/terraform-plugin-test
 # github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596
+github.com/hashicorp/terraform-svchost/disco
 github.com/hashicorp/terraform-svchost
 github.com/hashicorp/terraform-svchost/auth
-github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
@@ -204,130 +204,129 @@ github.com/mitchellh/mapstructure
 github.com/mitchellh/reflectwalk
 # github.com/oklog/run v1.0.0
 github.com/oklog/run
-# github.com/ovirt/go-ovirt v0.0.0-20210112072624-e4d3b104de71
+# github.com/ovirt/go-ovirt v0.0.0-20210308100159-ac0bcbc88d7c
 github.com/ovirt/go-ovirt
 # github.com/posener/complete v1.2.1
 github.com/posener/complete
-github.com/posener/complete/cmd
 github.com/posener/complete/cmd/install
+github.com/posener/complete/cmd
 github.com/posener/complete/match
 # github.com/spf13/afero v1.2.2
 github.com/spf13/afero
 github.com/spf13/afero/mem
 # github.com/ulikunitz/xz v0.5.5
 github.com/ulikunitz/xz
-github.com/ulikunitz/xz/internal/hash
 github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
+github.com/ulikunitz/xz/internal/hash
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
 # github.com/zclconf/go-cty v1.2.1
 github.com/zclconf/go-cty/cty
+github.com/zclconf/go-cty/cty/msgpack
 github.com/zclconf/go-cty/cty/convert
+github.com/zclconf/go-cty/cty/json
+github.com/zclconf/go-cty/cty/gocty
+github.com/zclconf/go-cty/cty/set
 github.com/zclconf/go-cty/cty/function
 github.com/zclconf/go-cty/cty/function/stdlib
-github.com/zclconf/go-cty/cty/gocty
-github.com/zclconf/go-cty/cty/json
-github.com/zclconf/go-cty/cty/msgpack
-github.com/zclconf/go-cty/cty/set
 # github.com/zclconf/go-cty-yaml v1.0.1
 github.com/zclconf/go-cty-yaml
 # go.opencensus.io v0.22.0
-go.opencensus.io
-go.opencensus.io/internal
-go.opencensus.io/internal/tagencoding
-go.opencensus.io/metric/metricdata
-go.opencensus.io/metric/metricproducer
+go.opencensus.io/trace
 go.opencensus.io/plugin/ochttp
+go.opencensus.io/internal
+go.opencensus.io/trace/internal
+go.opencensus.io/trace/tracestate
 go.opencensus.io/plugin/ochttp/propagation/b3
-go.opencensus.io/resource
 go.opencensus.io/stats
-go.opencensus.io/stats/internal
 go.opencensus.io/stats/view
 go.opencensus.io/tag
-go.opencensus.io/trace
-go.opencensus.io/trace/internal
 go.opencensus.io/trace/propagation
-go.opencensus.io/trace/tracestate
+go.opencensus.io
+go.opencensus.io/metric/metricdata
+go.opencensus.io/stats/internal
+go.opencensus.io/internal/tagencoding
+go.opencensus.io/metric/metricproducer
+go.opencensus.io/resource
 # golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
-golang.org/x/crypto/bcrypt
-golang.org/x/crypto/blowfish
-golang.org/x/crypto/cast5
 golang.org/x/crypto/openpgp
 golang.org/x/crypto/openpgp/armor
-golang.org/x/crypto/openpgp/elgamal
 golang.org/x/crypto/openpgp/errors
 golang.org/x/crypto/openpgp/packet
 golang.org/x/crypto/openpgp/s2k
+golang.org/x/crypto/bcrypt
+golang.org/x/crypto/cast5
+golang.org/x/crypto/openpgp/elgamal
+golang.org/x/crypto/blowfish
 # golang.org/x/net v0.0.0-20191009170851-d66e71096ffb
 golang.org/x/net/context
-golang.org/x/net/context/ctxhttp
-golang.org/x/net/http/httpguts
+golang.org/x/net/trace
+golang.org/x/net/internal/timeseries
 golang.org/x/net/http2
 golang.org/x/net/http2/hpack
 golang.org/x/net/idna
-golang.org/x/net/internal/timeseries
-golang.org/x/net/trace
+golang.org/x/net/http/httpguts
+golang.org/x/net/context/ctxhttp
 # golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 golang.org/x/oauth2
-golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
+golang.org/x/oauth2/google
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa
 golang.org/x/sys/unix
 # golang.org/x/text v0.3.2
-golang.org/x/text/secure/bidirule
-golang.org/x/text/transform
-golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
+golang.org/x/text/transform
+golang.org/x/text/secure/bidirule
+golang.org/x/text/unicode/bidi
 # google.golang.org/api v0.9.0
-google.golang.org/api/gensupport
-google.golang.org/api/googleapi
-google.golang.org/api/googleapi/internal/uritemplates
-google.golang.org/api/googleapi/transport
-google.golang.org/api/internal
 google.golang.org/api/iterator
+google.golang.org/api/googleapi
 google.golang.org/api/option
 google.golang.org/api/storage/v1
 google.golang.org/api/transport/http
+google.golang.org/api/googleapi/internal/uritemplates
+google.golang.org/api/internal
+google.golang.org/api/gensupport
+google.golang.org/api/googleapi/transport
 google.golang.org/api/transport/http/internal/propagation
 # google.golang.org/appengine v1.6.1
-google.golang.org/appengine
 google.golang.org/appengine/datastore
+google.golang.org/appengine
 google.golang.org/appengine/datastore/internal/cloudkey
-google.golang.org/appengine/datastore/internal/cloudpb
 google.golang.org/appengine/internal
-google.golang.org/appengine/internal/app_identity
-google.golang.org/appengine/internal/base
 google.golang.org/appengine/internal/datastore
-google.golang.org/appengine/internal/log
+google.golang.org/appengine/urlfetch
+google.golang.org/appengine/internal/app_identity
 google.golang.org/appengine/internal/modules
+google.golang.org/appengine/datastore/internal/cloudpb
+google.golang.org/appengine/internal/base
+google.golang.org/appengine/internal/log
 google.golang.org/appengine/internal/remote_api
 google.golang.org/appengine/internal/urlfetch
-google.golang.org/appengine/urlfetch
 # google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55
-google.golang.org/genproto/googleapis/api/annotations
+google.golang.org/genproto/googleapis/rpc/status
 google.golang.org/genproto/googleapis/iam/v1
 google.golang.org/genproto/googleapis/rpc/code
-google.golang.org/genproto/googleapis/rpc/status
+google.golang.org/genproto/googleapis/api/annotations
 google.golang.org/genproto/googleapis/type/expr
 # google.golang.org/grpc v1.23.0
 google.golang.org/grpc
-google.golang.org/grpc/balancer
-google.golang.org/grpc/balancer/base
-google.golang.org/grpc/balancer/roundrobin
-google.golang.org/grpc/binarylog/grpc_binarylog_v1
-google.golang.org/grpc/codes
-google.golang.org/grpc/connectivity
+google.golang.org/grpc/test/bufconn
 google.golang.org/grpc/credentials
-google.golang.org/grpc/credentials/internal
+google.golang.org/grpc/health
+google.golang.org/grpc/health/grpc_health_v1
+google.golang.org/grpc/codes
+google.golang.org/grpc/status
+google.golang.org/grpc/balancer
+google.golang.org/grpc/balancer/roundrobin
+google.golang.org/grpc/connectivity
 google.golang.org/grpc/encoding
 google.golang.org/grpc/encoding/proto
 google.golang.org/grpc/grpclog
-google.golang.org/grpc/health
-google.golang.org/grpc/health/grpc_health_v1
 google.golang.org/grpc/internal
 google.golang.org/grpc/internal/backoff
 google.golang.org/grpc/internal/balancerload
@@ -336,7 +335,6 @@ google.golang.org/grpc/internal/channelz
 google.golang.org/grpc/internal/envconfig
 google.golang.org/grpc/internal/grpcrand
 google.golang.org/grpc/internal/grpcsync
-google.golang.org/grpc/internal/syscall
 google.golang.org/grpc/internal/transport
 google.golang.org/grpc/keepalive
 google.golang.org/grpc/metadata
@@ -347,6 +345,8 @@ google.golang.org/grpc/resolver/dns
 google.golang.org/grpc/resolver/passthrough
 google.golang.org/grpc/serviceconfig
 google.golang.org/grpc/stats
-google.golang.org/grpc/status
 google.golang.org/grpc/tap
-google.golang.org/grpc/test/bufconn
+google.golang.org/grpc/credentials/internal
+google.golang.org/grpc/balancer/base
+google.golang.org/grpc/binarylog/grpc_binarylog_v1
+google.golang.org/grpc/internal/syscall


### PR DESCRIPTION
This patch will introduce the AutoPinningPolicy. This will allow VMs to
automatically get the configuration for CPUs and NUMA. For high
performance VMs, it will be automatically set to `existing` policy.

- `adjust` policy will change the CPU topology based on the host
  topology, will set the vCPU pinning and NUMA nodes.
- `existing` policy will set the vCPU pinning and NUMA nodes with the
  existing VM CPU topology.
- `disabled` won't do nothing, and can used to disable the default high
  performance VM policy value.

Each VM using a policy will be pinned to each host within the cluster
with allowed migration. Once the user will add a host, he needs to
update the VMs, adding the new host to the pinned hosts.

This patch bump the go-ovirt SDK.

Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>