### PR TITLE
Switching versioning to v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## v4.4.5-r.0
+
+This version is a feature release and **breaks backwards compatibility**. It contains two changes:
+
+- [251: Introduce auto-pinning policy](https://github.com/oVirt/terraform-provider-ovirt/pull/251)
+- [254: Add certificate verification](https://github.com/oVirt/terraform-provider-ovirt/pull/253)
+
+Please check the above links for details on these changes. *This release is the first that matches the oVirt version it is built for.*
+
+## v0.99.0
+
+Dear community,
+
+We are in the process of catching up on open pull requests. In order to make that happen we are now tagging the version before merging PR's as 0.99.
+
+After this release we will be switching to a versioning system that aligns with the oVirt release it supports. If you have any questions please feel free to raise them as a GitHub issue.
+
 ## [v0.5.0](https://github.com/oVirt/terraform-provider-ovirt/tree/v0.5.0) (2021-01-07)
 
 [Full Changelog](https://github.com/oVirt/terraform-provider-ovirt/compare/v0.4.2...v0.5.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v4.4.5-r.0
+## v1.0.0
 
 This version is a feature release and **breaks backwards compatibility**. It contains two changes:
 

--- a/README.md
+++ b/README.md
@@ -18,18 +18,26 @@ While in the last five months, the upstream project was not actively maintained 
 
 If possible, I would surely be happy to contribute back to the upstream again. ^_^ .
 
+Versioning
+----------
+
+This provider uses semantic versioning. The following table contains the oVirt version support for provider versions:
+
+| Terraform Provider Version | oVirt version | Description |
+|----------------------------|---------------|-------------|
+| v1.0.0 | 4.4.5 | This release adds support for auto-pinning policy. |
 
 Requirements
 ------------
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.11.x
--	[Go](https://golang.org/doc/install) 1.12 (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.14 (to build the provider plugin)
 
 
 Developing The Provider
 -----------------------
 
-If you wish to work on the provider, you'll first need [Go](https://golang.org) installed on your machine (version 1.12+ is *required*). You'll also need to correctly setup a [GOPATH](https://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
+If you wish to work on the provider, you'll first need [Go](https://golang.org) installed on your machine (version 1.14+ is *required*). You'll also need to correctly setup a [GOPATH](https://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
 *Note:* This project uses [Go Modules](https://blog.golang.org/using-go-modules) making it safe to work with it outside of your existing [GOPATH](http://golang.org/doc/code.html#GOPATH). The instructions that follow assume a directory in your home directory outside of the standard GOPATH (i.e `$HOME/development/terraform-providers/`).
 


### PR DESCRIPTION
This PR changes to versioning the TF provider independently because we can't tag sub-versions from oVirt.