### PR TITLE
Allow creating affinity group rules without VMs

### DIFF
--- a/ovirt/resource_ovirt_affinity_group.go
+++ b/ovirt/resource_ovirt_affinity_group.go
@@ -106,23 +106,29 @@ func resourceOvirtAffinityGroupCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	vmRuleBuilder := ovirtsdk4.NewAffinityRuleBuilder()
-	if _, ok := d.GetOk("vm_list"); ok {
+	vmRuleBuilder.Enabled(false)
+	if vmPositive, ok := d.GetOkExists("vm_positive"); ok {
 		vmRuleBuilder.Enabled(true)
-		vmRuleBuilder.Positive(d.Get("vm_positive").(bool))
-		vmRuleBuilder.Enforcing(d.Get("vm_enforcing").(bool))
-	} else {
-		vmRuleBuilder.Enabled(false)
+		vmRuleBuilder.Positive(vmPositive.(bool))
 	}
+	if vmEnforcing, ok := d.GetOk("vm_enforcing"); ok {
+		vmRuleBuilder.Enabled(true)
+		vmRuleBuilder.Enforcing(vmEnforcing.(bool))
+	}
+
 	agBuilder.VmsRule(vmRuleBuilder.MustBuild())
 
 	hostRuleBuilder := ovirtsdk4.NewAffinityRuleBuilder()
-	if _, ok := d.GetOk("host_list"); ok {
+	hostRuleBuilder.Enabled(false)
+	if hostPositive, ok := d.GetOkExists("host_positive"); ok {
 		hostRuleBuilder.Enabled(true)
-		hostRuleBuilder.Positive(d.Get("host_positive").(bool))
-		hostRuleBuilder.Enforcing(d.Get("host_enforcing").(bool))
-	} else {
-		hostRuleBuilder.Enabled(false)
+		hostRuleBuilder.Positive(hostPositive.(bool))
 	}
+	if hostEnforcing, ok := d.GetOk("host_enforcing"); ok {
+		hostRuleBuilder.Enabled(true)
+		hostRuleBuilder.Enforcing(hostEnforcing.(bool))
+	}
+
 	agBuilder.HostsRule(hostRuleBuilder.MustBuild())
 
 	log.Printf("Creating %#v", agBuilder.MustBuild())


### PR DESCRIPTION
We should allow creating affinity groups rules with no VM list.
This is needed in case we want to create the VMs later to join the affinity group.
The current state is that the affinity group rule will just not get created and terraform will not notify on that
