### PR TITLE
add explicit hugepages support to vm

### DIFF
--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -168,6 +168,7 @@ The following arguments are supported:
 * `boot_devices` - (Optional) The boot devices for the vm (the enum supports cdrom, hd, or network).
 * `initialization` - (Optional) Configurations of initialization. The initialization structure is documented below. Changint this updates the VM's initialization. You can specify at most one initialization.
 * `auto_pinning_policy` - (Optional) The policy for automatically pinning the CPUs and NUMAs of the VM. High Performance VMs default is `existing`.
+* `hugepages` - (Optional) The hugepages size the VM should use. Default is disabled (no hugepages usage). The valid values are `2048` or `1048576`.
 
 The `block_device` block supports:
 

--- a/ovirt/resource_ovirt_vm.go
+++ b/ovirt/resource_ovirt_vm.go
@@ -370,6 +370,15 @@ func resourceOvirtVM() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"hugepages": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The size of hugepage to use in KiB, One of 2048 or 1048576",
+				ValidateFunc: validation.IntInSlice([]int{
+					2048,
+					1048576,
+				}),
+			},
 		},
 	}
 }
@@ -631,6 +640,17 @@ func resourceOvirtVMCreate(d *schema.ResourceData, meta interface{}) error {
 				vmBuilder.PlacementPolicy(placementPolicy)
 			}
 		}
+	}
+
+	if v, ok := d.GetOk("hugepages"); ok {
+		customProp, err := ovirtsdk4.NewCustomPropertyBuilder().
+			Name("hugepages").
+			Value(fmt.Sprint(v)).
+			Build()
+		if err != nil {
+			return err
+		}
+		vmBuilder.CustomPropertiesOfAny(customProp)
 	}
 
 	if v, ok := d.GetOk("instance_type_id"); ok {


### PR DESCRIPTION
This patch will allow setting the `hugepages` custom property to a VM.
The values for 86_64 arch are `2048` (2 MiB) and `1048576` (1 GiB). The
host should have enough hugepages with the right size in order to use
this value.

Signed-off-by: Liran Rotenberg <lrotenbe@redhat.com>