### PR TITLE
remove vm_list from affinity group resource

### DIFF
--- a/ovirt/resource_ovirt_affinity_group_test.go
+++ b/ovirt/resource_ovirt_affinity_group_test.go
@@ -45,7 +45,6 @@ func TestAccOvirtAffinityGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "host_positive", "true"),
 					resource.TestCheckResourceAttr(resourceName, "vm_enforcing", "false"),
 					resource.TestCheckResourceAttr(resourceName, "vm_positive", "false"),
-					resource.TestCheckNoResourceAttr(resourceName, "vm_list"),
 				),
 			},
 		},
@@ -184,7 +183,6 @@ resource "ovirt_affinity_group" "affinity_group" {
 
   vm_enforcing = false
   vm_positive = true
-  vm_list = local.vms
 
 }
 `, rString, rString)


### PR DESCRIPTION
You can now add a VM to an affinity group on creation, a feature we didn't have when the affinity group resource was implemented.

Because a VM can join an affinity group in 2 ways it could lead to inconsistencies in the tfstate.

We are removing the ability to collect existing VMs into an affinity group since this path is the least recommended approach because it will cause the affinity group to be best effort