### PR TITLE
Read vm nics & high availability

### DIFF
--- a/ovirt/resource_ovirt_vm.go
+++ b/ovirt/resource_ovirt_vm.go
@@ -1088,6 +1088,7 @@ func resourceOvirtVMRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("threads", vm.MustCpu().MustTopology().MustThreads())
 	d.Set("cluster_id", vm.MustCluster().MustId())
 	d.Set("maximum_memory", vm.MustMemoryPolicy().MustMax()/int64(math.Pow(2, 20)))
+	d.Set("high_availability", vm.MustHighAvailability().MustEnabled())
 
 	if it, ok := vm.InstanceType(); ok {
 		d.Set("instance_type_id", it.MustId())


### PR DESCRIPTION
I'm importing some VMs into TF, but the `resourceOvirtVMRead` function doesn't pick up all of the state - the critical one here being that it doesn't pick up the NICs, which then forces destroy/recreate. 

This PR ensures the read function picks up VM nics and high_availability status. I'm aware there is a desire to separate out NIC management into a dedicated resource (which makes sense, creating a new nic shouldn't force a new VM as it does now). However until that happens the VM resource should manage them properly.

I'm not setting MACs anywhere in my tf files. It's possible (probable?) that if you import a VM with this, and have a MAC set in TF, it will force recreation. However this isn't any worse off than the current state. The long term proper fix for this is to probably split out the NIC as described above.
