### PR TITLE
use the new auto pinning naming

### DIFF
--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -167,7 +167,7 @@ The following arguments are supported:
 * `block_device` - (Optional) Configurations of bootable disk block device. The block_device structure is documented below. Changing this creates a new VM. You can specify at most one block_device.
 * `boot_devices` - (Optional) The boot devices for the vm (the enum supports cdrom, hd, or network).
 * `initialization` - (Optional) Configurations of initialization. The initialization structure is documented below. Changint this updates the VM's initialization. You can specify at most one initialization.
-* `auto_pinning_policy` - (Optional) The policy for automatically pinning the CPUs and NUMAs of the VM. High Performance VMs default is `existing`.
+* `auto_pinning_policy` - (Optional) The policy for automatically pinning the CPUs and NUMAs of the VM.
 * `hugepages` - (Optional) The hugepages size the VM should use. Default is disabled (no hugepages usage). The valid values are `2048` or `1048576`.
 
 The `block_device` block supports:


### PR DESCRIPTION
Since ovirt 4.4.7, ovirt changed the auto pinning policies naming(UI).
This patch will allow using the new names to align with it. The
previous names are staying to support backward compatibilty.