### PR TITLE
set insecure default value to false

### DIFF
--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -48,7 +48,7 @@ func (c *providerContext) Provider() terraform.ResourceProvider {
 				Type:        schema.TypeBool,
 				Required:    false,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OVIRT_INSECURE", ""),
+				DefaultFunc: schema.EnvDefaultFunc("OVIRT_INSECURE", false),
 				Description: "Skip certificate verification",
 				Sensitive:   false,
 			},


### PR DESCRIPTION
This patch resolves issue #268 [1] by setting the insecure default value
to false instead of an empty string.

[1] https://github.com/oVirt/terraform-provider-ovirt/issues/268

Signed-off-by: Eli Mesika <emesika@redhat.com>

<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Change 1
* Change 2

Output from acceptance testing:

```
$ make testacc TEST=./ovirt TESTARGS='-run=TestAccOvirtDataCenter_'

...
```
