### PR TITLE
Adding terraform provider packages

### DIFF
--- a/.github/workflows/compile-ocp-installer.yml
+++ b/.github/workflows/compile-ocp-installer.yml
@@ -15,7 +15,7 @@ jobs:
       - name: prepare env
         run: |
            mkdir -p ${GITHUB_WORKSPACE}/BUILDROOT  ${GITHUB_WORKSPACE}/SOURCES
-           yum install -y git createrepo_c rpm-build golang
+           yum install -y git createrepo_c rpm-build golang make
       - name: clone OCP installer and compile it with terraform provider patch 
         run: | 
           echo "WORKSPACE is ${GITHUB_WORKSPACE}"
@@ -24,30 +24,34 @@ jobs:
           git clone https://github.com/openshift/installer
           INSTALLER_PATH=$(pwd)/installer
           echo cloning installer completed
-          rm -rf ${INSTALLER_PATH}/vendor/github.com/ovirt/terraform-provider-ovirt/
-          mkdir ${INSTALLER_PATH}/vendor/github.com/ovirt/terraform-provider-ovirt
+          rm -rf ${INSTALLER_PATH}/vendor/github.com/ovirt/terraform-provider-ovirt
+          mkdir -p ${INSTALLER_PATH}/vendor/github.com/ovirt/terraform-provider-ovirt
           echo start copy of terraform provider dir to installer
           cp -r ${GITHUB_WORKSPACE}/* ${INSTALLER_PATH}/vendor/github.com/ovirt/terraform-provider-ovirt/
           echo copy of terraform provider dir to installer completed
           echo compiling OCP installer
-          cd installer
+          cd ${INSTALLER_PATH}
           ./hack/build.sh
           echo compiling OCP installer completed
+          echo building terraform provider executable
+          cd ${INSTALLER_PATH}/vendor/github.com/ovirt/terraform-provider-ovirt
+          make fmt
+          make release
       - name : Build RPM
         run: |
           echo generating package suffix
           cd ${GITHUB_WORKSPACE}
           cd ../../
           INSTALLER_PATH=$(pwd)/installer
-          cd ${INSTALLER_PATH}/vendor/github.com/ovirt/terraform-provider-ovirt/
+          TR_PATH=${INSTALLER_PATH}/vendor/github.com/ovirt/terraform-provider-ovirt/bin
+          cd ${INSTALLER_PATH}
           SUFFIX=.$(date -u +%Y%m%d%H%M%S).git$(git rev-parse --short HEAD)
-          echo "SUFFIX=${SUFFIX}"
           echo prepering files for rpmbuild
           mkdir -p ${GITHUB_WORKSPACE}/ocp-installer-bin
           cd ${GITHUB_WORKSPACE}
-          cp ${INSTALLER_PATH}/bin/openshift-install ${GITHUB_WORKSPACE}/ocp-installer-bin/
-          cp ${INSTALLER_PATH}/bin/openshift-install ${GITHUB_WORKSPACE}/SOURCES/
-          tar cvzf  tr-ocp-installer.tar.gz ${GITHUB_WORKSPACE}/ocp-installer-bin/
+          cp ${INSTALLER_PATH}/bin/openshift-install ${TR_PATH}/terraform-provider-ovirt_linux_amd64 ${GITHUB_WORKSPACE}/ocp-installer-bin/
+          cp ${INSTALLER_PATH}/bin/openshift-install ${TR_PATH}/terraform-provider-ovirt_linux_amd64 ${GITHUB_WORKSPACE}/SOURCES/
+          tar cvzf tr-ocp-installer.tar.gz ${GITHUB_WORKSPACE}/ocp-installer-bin/
           cp tr-ocp-installer.tar.gz ${GITHUB_WORKSPACE}/SOURCES
           rpmbuild -D "_topdir ${GITHUB_WORKSPACE}" -D "release_suffix ${SUFFIX}" -ba tr-ocp-installer.spec
       - name: Collect artifacts

--- a/tr-ocp-installer.spec
+++ b/tr-ocp-installer.spec
@@ -1,5 +1,5 @@
 Name:		tr-ocp-installer
-Version:	1.0.0
+Version:	1.0.1
 Release:	0.0.master%{?release_suffix}%{?dist}
 License:	ASL 2.0
 Summary:	OCP installer with terraform provider patch
@@ -9,15 +9,18 @@ BuildArch:	x86_64
 Source:         tr-ocp-installer.tar.gz
 
 %description
-OCP installer binary compiled with terraform provider patch
+OCP installer binary compiled with terraform provider patch and terraform provider binary
 
 %install
 mkdir -p %{buildroot}/usr/bin/
-cp %{_sourcedir}/openshift-install %{buildroot}/usr/bin/
+cp %{_sourcedir}/openshift-install %{_sourcedir}/terraform-provider-ovirt_linux_amd64 %{buildroot}/usr/bin/
 
 %files
 /usr/bin/openshift-install
+/usr/bin/terraform-provider-ovirt_linux_amd64
 
 %changelog
+* Thu Feb 2 2022 Eli Mesika <emesika@redhat.com> 1.0.1
+- Added terraform provider executable
 * Thu Jan 13 2022 Eli Mesika <emesika@redhat.com> 1.0.0
 - Created


### PR DESCRIPTION
This patch adds the terraform provider go packages needed for terraform
init command as plugin sources.

Signed-off-by: emesika <emesika@redhat.com>

## Please describe the change you are making

...

## Are you the owner of the code you are sending in, or do you have permission of the owner?

...

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

...
