### PR TITLE
Do not generate src package

### DIFF
--- a/.github/workflows/compile-ocp-installer.yml
+++ b/.github/workflows/compile-ocp-installer.yml
@@ -53,7 +53,7 @@ jobs:
           cp ${INSTALLER_PATH}/bin/openshift-install ${TR_PATH}/terraform-provider-ovirt_linux_amd64 ${GITHUB_WORKSPACE}/SOURCES/
           tar cvzf tr-ocp-installer.tar.gz ${GITHUB_WORKSPACE}/ocp-installer-bin/
           cp tr-ocp-installer.tar.gz ${GITHUB_WORKSPACE}/SOURCES
-          rpmbuild -D "_topdir ${GITHUB_WORKSPACE}" -D "release_suffix ${SUFFIX}" -ba tr-ocp-installer.spec
+          rpmbuild -D "_topdir ${GITHUB_WORKSPACE}" -D "release_suffix ${SUFFIX}" -bb tr-ocp-installer.spec
       - name: Collect artifacts
         run: |
           echo collecting artifacts


### PR DESCRIPTION
Generate only tr-suite-master binaries rpm to save storage on engine VM.

Signed-off-by: Eli Mesika <emesika@redhat.com>

## Please describe the change you are making

...

## Are you the owner of the code you are sending in, or do you have permission of the owner?

...

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

...
