### PR TITLE
Adding a tr-suite-master trigger file

### DIFF
--- a/.github/tr-master-suite-trigger.yaml
+++ b/.github/tr-master-suite-trigger.yaml
@@ -1,0 +1,20 @@
+name: OST tr-suite-master trigger
+ 
+on:
+  issue_comment:
+    types: [created]
+ 
+jobs:
+  trigger-ost:
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/ost') &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    uses: oVirt/ovirt-system-tests/.github/workflows/ost.yaml@master
+    with:
+      pr_url: ${{ github.event.issue.pull_request.url }}
+      suite: tr-suite-master
+      distro: rhel8


### PR DESCRIPTION
Adds a tr-suite-master trigger file in order to run OST on
tr-suite-master suite using the passed PR URL and distro

Signed-off-by: Eli Mesika emesika@rehat.com

## Please describe the change you are making

...

## Are you the owner of the code you are sending in, or do you have permission of the owner?

...

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

...
