### PR TITLE
dummy patch to test OST

### DIFF
--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -29,3 +29,5 @@ PROVIDER_URL="https:\/\/github.com\/ovirt\/terraform-provider-ovirt\/issues"
 $SED "s/GH-([0-9]+)/\[#\1\]\($PROVIDER_URL\/\1\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
 
 rm CHANGELOG.md.bak
+
+echo "done, exiting ...."


### PR DESCRIPTION
This is a dummy patch that will be removed after testing OST
tr-suite-master that should be run on each and every change in this repo
to ensure that OCP installer is not affected by the patch.

Signed-off-by: Eli Mesika <emesika@redhat.com>

## Please describe the change you are making

...

## Are you the owner of the code you are sending in, or do you have permission of the owner?

...

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

...
