### PR TITLE
Fix panic no context in logger

### DIFF
--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -137,7 +137,7 @@ func (p *provider) getProviderFactories() map[string]func() (*schema.Provider, e
 	}
 }
 
-func (p *provider) configureProvider(_ context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
+func (p *provider) configureProvider(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
 	if mock, ok := data.GetOk("mock"); ok && mock == true {
@@ -212,7 +212,7 @@ func (p *provider) configureProvider(_ context.Context, data *schema.ResourceDat
 		username,
 		password,
 		tls,
-		&terraformLogger{},
+		newTerraformLogger().WithContext(ctx),
 		nil,
 	)
 	if err != nil {


### PR DESCRIPTION
## Please describe the change you are making

The terraform provider crashes when running an example, e.g. [ovirt_vm](https://github.com/oVirt/terraform-provider-ovirt/tree/main/examples/resources/ovirt_vm), with `mock=false` with the following panic:

```
panic: bug: the Terraform logger was used without calling WithContext

goroutine 73 [running]:
github.com/ovirt/terraform-provider-ovirt/ovirt.terraformLogger.Debugf({{0x0, 0x0}}, {0x1422fc6, 0x40c3a7}, {0xc00059e0c0, 0x11f9120, 0x1})
        /home/mengel/projects/ovirt/terraform-provider-ovirt/ovirt/logger.go:21 +0x9c
github.com/ovirt/go-ovirt-client.retry({0x143cb04, 0x15f2138}, {0x15f20f8, 0xc0001178b0}, {0xc00054e140, 0x6, 0x100}, 0xc0000ed2b0)
        /home/mengel/go/pkg/mod/github.com/ovirt/go-ovirt-client@v1.0.0-alpha5/retry.go:36 +0x1f3
github.com/ovirt/go-ovirt-client.(*oVirtClient).Test(0xc0000fc3c0, {0x0, 0x0, 0x0})
        /home/mengel/go/pkg/mod/github.com/ovirt/go-ovirt-client@v1.0.0-alpha5/testconnection.go:11 +0xdd
github.com/ovirt/go-ovirt-client.testConnection({0x16366a8, 0xc0000fc3c0})
        /home/mengel/go/pkg/mod/github.com/ovirt/go-ovirt-client@v1.0.0-alpha5/new.go:260 +0x31
github.com/ovirt/go-ovirt-client.(*oVirtClient).Reconnect(0xc0000fc3c0)
        /home/mengel/go/pkg/mod/github.com/ovirt/go-ovirt-client@v1.0.0-alpha5/client.go:118 +0x2a3
github.com/ovirt/go-ovirt-client.NewWithVerify({0xc00003d430, 0x0}, {0xc00003d450, 0x163}, {0xc00003d3e0, 0x3}, {0x15d2cc0, 0xc0001423f0}, {0x15f2138, 0xc0001178b0}, ...)
        /home/mengel/go/pkg/mod/github.com/ovirt/go-ovirt-client@v1.0.0-alpha5/new.go:200 +0x50d
github.com/ovirt/go-ovirt-client.New(...)
        /home/mengel/go/pkg/mod/github.com/ovirt/go-ovirt-client@v1.0.0-alpha5/new.go:149
github.com/ovirt/terraform-provider-ovirt/ovirt.(*provider).configureProvider(0xc0002887e0, {0x80, 0x13e0560}, 0x1)
        /home/mengel/projects/ovirt/terraform-provider-ovirt/ovirt/provider.go:210 +0x72b
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Provider).Configure(0xc0002809c0, {0x15ec620, 0xc0003fa480}, 0xd)
        /home/mengel/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.16.0/helper/schema/provider.go:297 +0x25e
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ConfigureProvider(0xc00029d860, {0x15ec578, 0xc00051ea80}, 0xc00000ed50)
        /home/mengel/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.16.0/helper/schema/grpc_provider.go:557 +0x345
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).Configure(0xc0002f4f00, {0x15ec620, 0xc00054b830}, 0xc00051e800)
        /home/mengel/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.9.0/tfprotov5/tf5server/server.go:555 +0x32b
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_Configure_Handler({0x13caac0, 0xc0002f4f00}, {0x15ec620, 0xc00054b830}, 0xc00051a3c0, 0x0)
        /home/mengel/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.9.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:331 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0002ae700, {0x1601688, 0xc0003c9380}, 0xc00025c5a0, 0xc0003fb5f0, 0x1edfef8, 0x0)
        /home/mengel/go/pkg/mod/google.golang.org/grpc@v1.46.0/server.go:1283 +0xcf2
google.golang.org/grpc.(*Server).handleStream(0xc0002ae700, {0x1601688, 0xc0003c9380}, 0xc00025c5a0, 0x0)
        /home/mengel/go/pkg/mod/google.golang.org/grpc@v1.46.0/server.go:1620 +0xa2a
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        /home/mengel/go/pkg/mod/google.golang.org/grpc@v1.46.0/server.go:922 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /home/mengel/go/pkg/mod/google.golang.org/grpc@v1.46.0/server.go:920 +0x294

Error: The terraform-provider-ovirt plugin crashed!
```

This is a result of passing the logger from the tf provider with uninitialized context to [ovirtclient.New](https://github.com/oVirt/terraform-provider-ovirt/blob/main/ovirt/provider.go#L215) and it being passed down all the way to the [go-ovirt-client's logging in retry](https://github.com/oVirt/go-ovirt-client/blob/main/retry.go#L36) so that the [panic in the tf logger impl](https://github.com/oVirt/terraform-provider-ovirt/blob/main/ovirt/logger.go#L20-L22) is triggered. 

This PR attempts to solve this by setting the context of the logger. 

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

yes
