### PR TITLE
Added test runner for all examples if live credentials are present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 .idea
 *.iml
 dist
+.terraform.tfstate.lock.info
+*.tfstate
+*.tfstate.*
+**/.terraform/*
+crash.log
+crash.*.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,6 +273,8 @@ Did we mention you may want to avoid blocks whenever possible?
 
 So far so good, you have a resource that works in theory. In practice Terraform can be a tricky beast to deal with though, so you should always write a test for your resource. We exclusively rely on the mocks provided by go-ovirt-client for this functionality, otherwise this provider would be a headache to test.
 
+Additionally, all examples in the [examples](examples) directory are executed automatically against a live engine if you provide the `OVIRT_URL`, `OVIRT_USERNAME`, and `OVIRT_PASSWORD` environment variables.
+
 In order to write a test you must create the appropriate test file and add your test:
 
 ```go

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,26 +18,34 @@ The oVirt provider interacts with the oVirt Engine / RHV Manager API. The provid
 ## Example Usage
 
 ```terraform
+terraform {
+  required_providers {
+    ovirt = {
+      source = "oVirt/ovirt"
+    }
+  }
+}
+
 provider "ovirt" {
   # Set this to your oVirt Engine URL, e.g. https://example.com/ovirt-engine/api/
-  url           = var.url
+  url = var.url
   # Set this to your oVirt username, e.g. admin@internal
-  username      = var.username
+  username = var.username
   # Set this to your oVirt password.
-  password      = var.password
+  password = var.password
   # Take trusted certificates from the specified files (list).
-  tls_ca_files  = var.tls_ca_files
+  tls_ca_files = var.tls_ca_files
   # Take trusted certificates from the specified directories (list).
-  tls_ca_dirs   = var.tls_ca_dirs
+  tls_ca_dirs = var.tls_ca_dirs
   # Take the trusted certificates from the provided variable. Certificates must be in PEM format.
   tls_ca_bundle = var.tls_ca_bundle
   # Set this to true to use the system certificate storage to verify the engine certificate. You must
   # add the certificate to your trusted roots before running. This option doesn't work on Windows.
-  tls_system    = var.tls_system
+  tls_system = var.tls_system
   # Set this to true to disable certificate verification. This is a terrible idea.
-  tls_insecure  = var.tls_insecure
+  tls_insecure = var.tls_insecure
   # Set to true if you want to run an in-memory test. In this mode all other options will be ignored.
-  mock          = var.mock
+  mock = var.mock
   # Set extra headers to add to each request.
   extra_headers = {
     "X-Custom-Header" = "Hello world!"

--- a/docs/resources/affinity_group.md
+++ b/docs/resources/affinity_group.md
@@ -14,8 +14,9 @@ The ovirt_affinity_group resource creates affinity groups in oVirt.
 
 ```terraform
 resource "ovirt_affinity_group" "test" {
-  name      = "test"
-  enforcing = true
+  name       = "test"
+  enforcing  = true
+  cluster_id = var.cluster_id
 
   hosts_rule {
     affinity  = "negative"

--- a/docs/resources/disk.md
+++ b/docs/resources/disk.md
@@ -16,7 +16,7 @@ The ovirt_disk resource creates disks in oVirt.
 resource "ovirt_disk" "test" {
   storagedomain_id = var.storagedomain_id
   format           = "raw"
-  size             = 512
+  size             = 1048576
   alias            = "test"
   sparse           = true
 }

--- a/docs/resources/disk_attachment.md
+++ b/docs/resources/disk_attachment.md
@@ -19,13 +19,13 @@ The ovirt_disk_attachment resource attaches a single disk to a single VM. For co
 resource "ovirt_disk" "test" {
   storagedomain_id = var.storagedomain_id
   format           = "raw"
-  size             = 512
+  size             = 1048576
   alias            = "test"
   sparse           = true
 }
 
 resource "ovirt_vm" "test" {
-  name        = "hello_world"
+  name        = random_string.vm_name.result
   comment     = "Hello world!"
   cluster_id  = var.cluster_id
   template_id = "00000000-0000-0000-0000-000000000000"

--- a/docs/resources/disk_attachments.md
+++ b/docs/resources/disk_attachments.md
@@ -19,20 +19,20 @@ The ovirt_disk_attachments resource attaches multiple disks to a single VM in on
 resource "ovirt_disk" "test" {
   storagedomain_id = var.storagedomain_id
   format           = "raw"
-  size             = 512
+  size             = 1048576
   alias            = "test"
   sparse           = true
 }
 
 resource "ovirt_vm" "test" {
-  name        = "hello_world"
+  name        = random_string.vm_name.result
   comment     = "Hello world!"
   cluster_id  = var.cluster_id
   template_id = "00000000-0000-0000-0000-000000000000"
 }
 
 resource "ovirt_disk_attachments" "test" {
-  vm_id            = ovirt_vm.test.id
+  vm_id = ovirt_vm.test.id
   # Set the following to true to completely remove non-listed attached disks. This can be used to wipe disks from the
   # template.
   remove_unmanaged = false

--- a/docs/resources/nic.md
+++ b/docs/resources/nic.md
@@ -14,7 +14,7 @@ The ovirt_nic resource creates network interfaces in oVirt.
 
 ```terraform
 resource "ovirt_vm" "test" {
-  name        = "hello_world"
+  name        = random_string.vm_name.result
   comment     = "Hello world!"
   cluster_id  = var.cluster_id
   template_id = "00000000-0000-0000-0000-000000000000"

--- a/docs/resources/tag.md
+++ b/docs/resources/tag.md
@@ -14,11 +14,11 @@ The ovirt_tag resource creates tags for virtual machines to use.
 
 ```terraform
 resource "ovirt_tag" "test" {
-  name        = "hello_world"
+  name = random_string.tag_name.result
 }
 
 resource "ovirt_vm" "test" {
-  name        = "hello_world"
+  name        = random_string.vm_name.result
   comment     = "Hello world!"
   cluster_id  = var.cluster_id
   template_id = "00000000-0000-0000-0000-000000000000"
@@ -26,7 +26,7 @@ resource "ovirt_vm" "test" {
 
 resource "ovirt_vm_tag" "test" {
   tag_id = ovirt_tag.test.id
-  vm_id = ovirt_vm.test.id
+  vm_id  = ovirt_vm.test.id
 }
 ```
 

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -14,7 +14,7 @@ The ovirt_vm resource creates a virtual machine in oVirt.
 
 ```terraform
 resource "ovirt_vm" "test" {
-  name        = "hello_world"
+  name        = random_string.vm_name.result
   comment     = "Hello world!"
   cluster_id  = var.cluster_id
   template_id = "00000000-0000-0000-0000-000000000000"

--- a/docs/resources/vm_tag.md
+++ b/docs/resources/vm_tag.md
@@ -14,11 +14,11 @@ The ovirt_vm_tag resource attaches a tag to a virtual machine.
 
 ```terraform
 resource "ovirt_tag" "test" {
-  name        = "hello_world"
+  name = random_string.tag_name.result
 }
 
 resource "ovirt_vm" "test" {
-  name        = "hello_world"
+  name        = random_string.vm_name.result
   comment     = "Hello world!"
   cluster_id  = var.cluster_id
   template_id = "00000000-0000-0000-0000-000000000000"
@@ -26,7 +26,7 @@ resource "ovirt_vm" "test" {
 
 resource "ovirt_vm_tag" "test" {
   tag_id = ovirt_tag.test.id
-  vm_id = ovirt_vm.test.id
+  vm_id  = ovirt_vm.test.id
 }
 ```
 

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -1,0 +1,233 @@
+package examples
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	ovirtclient "github.com/ovirt/go-ovirt-client"
+	ovirtclientlog "github.com/ovirt/go-ovirt-client-log/v3"
+)
+
+func TestExamples(t *testing.T) {
+	ovirtURL := os.Getenv("OVIRT_URL")
+	ovirtUsername := os.Getenv("OVIRT_USERNAME")
+	ovirtPassword := os.Getenv("OVIRT_PASSWORD")
+
+	if ovirtURL == "" || ovirtUsername == "" || ovirtPassword == "" {
+		t.Skipf("OVIRT_URL, OVIRT_USERNAME, or OVIRT_PASSWORD no set, skipping test.")
+	}
+
+	helper, err := ovirtclient.NewTestHelper(
+		ovirtURL,
+		ovirtUsername,
+		ovirtPassword,
+		nil,
+		ovirtclient.TLS().Insecure(),
+		false,
+		ovirtclientlog.NewTestLogger(t),
+	)
+	if err != nil {
+		t.Fatalf("Failed to initialize the oVirt client (%v)", err)
+	}
+
+	tfVars := tfvars{
+		ovirtUsername,
+		ovirtPassword,
+		ovirtURL,
+		helper.GetStorageDomainID(),
+		helper.GetClusterID(),
+		helper.GetVNICProfileID(),
+		true,
+	}
+	t.Run(
+		"provider", func(t *testing.T) {
+			runTerraform(
+				t, "provider", tfVars,
+			)
+		},
+	)
+
+	for _, category := range []string{"resources", "data-sources"} {
+		t.Run(
+			category, func(t *testing.T) {
+				entries, err := ioutil.ReadDir(category)
+				if err != nil {
+					t.Fatalf("failed to read directory %s (%v)", category, err)
+				}
+				for _, e := range entries {
+					if e.IsDir() {
+						t.Run(
+							e.Name(), func(t *testing.T) {
+								runTerraform(
+									t, path.Join(category, e.Name()), tfVars,
+								)
+							},
+						)
+					}
+				}
+			},
+		)
+	}
+}
+
+func runTerraformCommand(t *testing.T, dir string, env []string, vars interface{}, args ...string) {
+	tmpDir := t.TempDir()
+	varsFileName := path.Join(tmpDir, "tfvars.json")
+
+	if vars != nil {
+		varsFile, err := os.Create(varsFileName)
+		if err != nil {
+			t.Fatalf("Failed to create temporary file for Terraform variables. (%v)", err)
+		}
+		defer func() {
+			_ = os.Remove(varsFileName)
+		}()
+		encoder := json.NewEncoder(varsFile)
+		if err := encoder.Encode(vars); err != nil {
+			t.Fatalf("Failed to encode tfvars (%v)", err)
+		}
+		if err := varsFile.Close(); err != nil {
+			t.Fatalf("Failed to close tfvars file (%v)", err)
+		}
+		args = append(args, fmt.Sprintf("-var-file=%s", varsFileName))
+	}
+	t.Logf("Executing terraform %s ...", strings.Join(args, " "))
+
+	cmd := exec.Command("terraform", args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	lock := &sync.Mutex{}
+	prefix := "[terraform " + strings.Join(args, " ") + "] "
+	cmd.Stdout = &tLogger{t, lock, prefix}
+	cmd.Stderr = &tLogger{t, lock, prefix}
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to run terraform %s (%v)", strings.Join(args, " "), err)
+	}
+	t.Logf("Successfully ran terrafom %s.", strings.Join(args, " "))
+}
+
+func runTerraform(t *testing.T, dir string, vars tfvars) {
+	t.Logf("Starting Terraform provider...")
+	cmd := exec.Command("go", "run", "../main.go", "-debug")
+	logger := &tfReattachCaptureLogger{
+		t:      t,
+		ready:  make(chan string),
+		error:  make(chan error, 1),
+		prefix: "[go run ../main.go -debug] ",
+		lock:   &sync.Mutex{},
+	}
+
+	cmd.Stderr = logger
+	cmd.Stdout = logger
+	go func() {
+		defer close(logger.error)
+		t.Logf("Executing %s ...", cmd.Args)
+		err := cmd.Run()
+		if err != nil {
+			t.Logf("Program terminated with an error: %s (%v)", cmd.Args, err)
+			logger.error <- err
+		}
+		t.Logf("Program terminated normally: %s", cmd.Args)
+	}()
+
+	env := []string{}
+	select {
+	case line, ok := <-logger.ready:
+		if !ok {
+			t.Fatalf("Ready channel closed without submitting a TF_REATTACH_PROVIDERS line")
+		}
+		lineParts := strings.SplitN(line, "=", 2)
+		// Remove extra quotes from JSON output
+		lineParts[1] = strings.Trim(lineParts[1], "'")
+		line = strings.Join(lineParts, "=")
+		env = append(env, line)
+	case err, ok := <-logger.error:
+		if !ok {
+			t.Fatalf("Terraform provider closed the error channel without any output.")
+		}
+		t.Fatalf("Terraform provider exited with an error: %v", err)
+	case <-time.After(10 * time.Second):
+		t.Fatalf("Timeout while waiting for the TF_REATTACH_PROVIDERS line in the output.")
+	}
+	t.Cleanup(
+		func() {
+			t.Logf("Terminating %s ...", strings.Join(cmd.Args, " "))
+			if err := cmd.Process.Kill(); err != nil {
+				t.Fatalf("Failed to stop Terraform provider running in the background. (%v)", err)
+			}
+		},
+	)
+	runTerraformCommand(t, dir, env, nil, "init")
+	t.Cleanup(
+		func() {
+			runTerraformCommand(t, dir, env, vars, "destroy", "-auto-approve")
+		},
+	)
+	runTerraformCommand(t, dir, env, vars, "apply", "-auto-approve")
+}
+
+type tfvars struct {
+	Username        string                      `json:"username"`
+	Password        string                      `json:"password"`
+	URL             string                      `json:"url"`
+	StorageDomainID ovirtclient.StorageDomainID `json:"storagedomain_id"`
+	ClusterID       ovirtclient.ClusterID       `json:"cluster_id"`
+	VNICProfileID   ovirtclient.VNICProfileID   `json:"vnic_profile_id"`
+	TLSInsecure     bool                        `json:"tls_insecure"`
+}
+
+var tfReattachRe = regexp.MustCompile("TF_REATTACH_PROVIDERS=.*")
+
+type tfReattachCaptureLogger struct {
+	t      *testing.T
+	ready  chan string
+	error  chan error
+	prefix string
+	lock   *sync.Mutex
+}
+
+func (t tfReattachCaptureLogger) Write(p []byte) (n int, err error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.t.Helper()
+
+	lines := strings.Split(strings.TrimRight(string(p), "\n"), "\n")
+	for _, line := range lines {
+		t.t.Logf("%s%s", t.prefix, line)
+	}
+
+	matches := tfReattachRe.Find(p)
+	if len(matches) != 0 {
+		t.t.Logf("Found TF_REATTACH_PROVIDERS line in output.")
+		t.ready <- string(matches)
+		close(t.ready)
+	}
+	return len(p), nil
+}
+
+type tLogger struct {
+	t      *testing.T
+	lock   *sync.Mutex
+	prefix string
+}
+
+func (t tLogger) Write(p []byte) (n int, err error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.t.Helper()
+
+	lines := strings.Split(strings.TrimRight(string(p), "\n"), "\n")
+	for _, line := range lines {
+		t.t.Logf("%s%s", t.prefix, line)
+	}
+	return len(p), nil
+}

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,23 +1,31 @@
+terraform {
+  required_providers {
+    ovirt = {
+      source = "oVirt/ovirt"
+    }
+  }
+}
+
 provider "ovirt" {
   # Set this to your oVirt Engine URL, e.g. https://example.com/ovirt-engine/api/
-  url           = var.url
+  url = var.url
   # Set this to your oVirt username, e.g. admin@internal
-  username      = var.username
+  username = var.username
   # Set this to your oVirt password.
-  password      = var.password
+  password = var.password
   # Take trusted certificates from the specified files (list).
-  tls_ca_files  = var.tls_ca_files
+  tls_ca_files = var.tls_ca_files
   # Take trusted certificates from the specified directories (list).
-  tls_ca_dirs   = var.tls_ca_dirs
+  tls_ca_dirs = var.tls_ca_dirs
   # Take the trusted certificates from the provided variable. Certificates must be in PEM format.
   tls_ca_bundle = var.tls_ca_bundle
   # Set this to true to use the system certificate storage to verify the engine certificate. You must
   # add the certificate to your trusted roots before running. This option doesn't work on Windows.
-  tls_system    = var.tls_system
+  tls_system = var.tls_system
   # Set this to true to disable certificate verification. This is a terrible idea.
-  tls_insecure  = var.tls_insecure
+  tls_insecure = var.tls_insecure
   # Set to true if you want to run an in-memory test. In this mode all other options will be ignored.
-  mock          = var.mock
+  mock = var.mock
   # Set extra headers to add to each request.
   extra_headers = {
     "X-Custom-Header" = "Hello world!"

--- a/examples/resources/ovirt_affinity_group/provider.tf
+++ b/examples/resources/ovirt_affinity_group/provider.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     ovirt = {
       source  = "ovirt/ovirt"
-      version = "0.3.0"
     }
   }
 

--- a/examples/resources/ovirt_affinity_group/resource.tf
+++ b/examples/resources/ovirt_affinity_group/resource.tf
@@ -1,6 +1,7 @@
 resource "ovirt_affinity_group" "test" {
-  name      = "test"
-  enforcing = true
+  name       = "test"
+  enforcing  = true
+  cluster_id = var.cluster_id
 
   hosts_rule {
     affinity  = "negative"

--- a/examples/resources/ovirt_affinity_group/variables.tf
+++ b/examples/resources/ovirt_affinity_group/variables.tf
@@ -1,5 +1,9 @@
-variable "storagedomain_id" {
+variable "cluster_id" {
   type = string
+}
+
+variable "storagedomain_id" {
+  type        = string
   description = "ID of the storage domain to create the disk on."
 }
 

--- a/examples/resources/ovirt_disk/provider.tf
+++ b/examples/resources/ovirt_disk/provider.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     ovirt = {
       source  = "ovirt/ovirt"
-      version = "0.3.0"
     }
   }
 

--- a/examples/resources/ovirt_disk/resource.tf
+++ b/examples/resources/ovirt_disk/resource.tf
@@ -1,7 +1,7 @@
 resource "ovirt_disk" "test" {
   storagedomain_id = var.storagedomain_id
   format           = "raw"
-  size             = 512
+  size             = 1048576
   alias            = "test"
   sparse           = true
 }

--- a/examples/resources/ovirt_disk/variables.tf
+++ b/examples/resources/ovirt_disk/variables.tf
@@ -1,5 +1,5 @@
 variable "storagedomain_id" {
-  type = string
+  type        = string
   description = "ID of the storage domain to create the disk on."
 }
 

--- a/examples/resources/ovirt_disk_attachment/provider.tf
+++ b/examples/resources/ovirt_disk_attachment/provider.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     ovirt = {
       source  = "ovirt/ovirt"
-      version = "0.3.0"
     }
   }
 

--- a/examples/resources/ovirt_disk_attachment/resource.tf
+++ b/examples/resources/ovirt_disk_attachment/resource.tf
@@ -1,13 +1,13 @@
 resource "ovirt_disk" "test" {
   storagedomain_id = var.storagedomain_id
   format           = "raw"
-  size             = 512
+  size             = 1048576
   alias            = "test"
   sparse           = true
 }
 
 resource "ovirt_vm" "test" {
-  name        = "hello_world"
+  name        = random_string.vm_name.result
   comment     = "Hello world!"
   cluster_id  = var.cluster_id
   template_id = "00000000-0000-0000-0000-000000000000"

--- a/examples/resources/ovirt_disk_attachment/variables.tf
+++ b/examples/resources/ovirt_disk_attachment/variables.tf
@@ -1,5 +1,5 @@
 variable "storagedomain_id" {
-  type = string
+  type        = string
   description = "ID of the storage domain to create the disk on."
 }
 
@@ -40,4 +40,8 @@ variable "tls_system" {
 variable "mock" {
   type    = bool
   default = true
+}
+resource "random_string" "vm_name" {
+  length  = 16
+  special = false
 }

--- a/examples/resources/ovirt_disk_attachments/provider.tf
+++ b/examples/resources/ovirt_disk_attachments/provider.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     ovirt = {
       source  = "ovirt/ovirt"
-      version = "0.3.0"
     }
   }
 

--- a/examples/resources/ovirt_disk_attachments/resource.tf
+++ b/examples/resources/ovirt_disk_attachments/resource.tf
@@ -1,20 +1,20 @@
 resource "ovirt_disk" "test" {
   storagedomain_id = var.storagedomain_id
   format           = "raw"
-  size             = 512
+  size             = 1048576
   alias            = "test"
   sparse           = true
 }
 
 resource "ovirt_vm" "test" {
-  name        = "hello_world"
+  name        = random_string.vm_name.result
   comment     = "Hello world!"
   cluster_id  = var.cluster_id
   template_id = "00000000-0000-0000-0000-000000000000"
 }
 
 resource "ovirt_disk_attachments" "test" {
-  vm_id            = ovirt_vm.test.id
+  vm_id = ovirt_vm.test.id
   # Set the following to true to completely remove non-listed attached disks. This can be used to wipe disks from the
   # template.
   remove_unmanaged = false

--- a/examples/resources/ovirt_disk_attachments/variables.tf
+++ b/examples/resources/ovirt_disk_attachments/variables.tf
@@ -1,5 +1,5 @@
 variable "storagedomain_id" {
-  type = string
+  type        = string
   description = "ID of the storage domain to create the disk on."
 }
 
@@ -40,4 +40,8 @@ variable "tls_system" {
 variable "mock" {
   type    = bool
   default = true
+}
+resource "random_string" "vm_name" {
+  length  = 16
+  special = false
 }

--- a/examples/resources/ovirt_nic/provider.tf
+++ b/examples/resources/ovirt_nic/provider.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     ovirt = {
       source  = "ovirt/ovirt"
-      version = "0.3.0"
     }
   }
 

--- a/examples/resources/ovirt_nic/resource.tf
+++ b/examples/resources/ovirt_nic/resource.tf
@@ -1,5 +1,5 @@
 resource "ovirt_vm" "test" {
-  name        = "hello_world"
+  name        = random_string.vm_name.result
   comment     = "Hello world!"
   cluster_id  = var.cluster_id
   template_id = "00000000-0000-0000-0000-000000000000"

--- a/examples/resources/ovirt_nic/variables.tf
+++ b/examples/resources/ovirt_nic/variables.tf
@@ -40,3 +40,8 @@ variable "mock" {
   type    = bool
   default = true
 }
+
+resource "random_string" "vm_name" {
+  length  = 16
+  special = false
+}

--- a/examples/resources/ovirt_tag/provider.tf
+++ b/examples/resources/ovirt_tag/provider.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     ovirt = {
       source  = "ovirt/ovirt"
-      version = "0.3.0"
     }
   }
 

--- a/examples/resources/ovirt_tag/resource.tf
+++ b/examples/resources/ovirt_tag/resource.tf
@@ -1,9 +1,9 @@
 resource "ovirt_tag" "test" {
-  name        = "hello_world"
+  name = random_string.tag_name.result
 }
 
 resource "ovirt_vm" "test" {
-  name        = "hello_world"
+  name        = random_string.vm_name.result
   comment     = "Hello world!"
   cluster_id  = var.cluster_id
   template_id = "00000000-0000-0000-0000-000000000000"
@@ -11,5 +11,5 @@ resource "ovirt_vm" "test" {
 
 resource "ovirt_vm_tag" "test" {
   tag_id = ovirt_tag.test.id
-  vm_id = ovirt_vm.test.id
+  vm_id  = ovirt_vm.test.id
 }

--- a/examples/resources/ovirt_tag/variables.tf
+++ b/examples/resources/ovirt_tag/variables.tf
@@ -40,3 +40,11 @@ variable "mock" {
   type    = bool
   default = true
 }
+resource "random_string" "vm_name" {
+  length  = 16
+  special = false
+}
+resource "random_string" "tag_name" {
+  length  = 16
+  special = false
+}

--- a/examples/resources/ovirt_vm/provider.tf
+++ b/examples/resources/ovirt_vm/provider.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     ovirt = {
       source  = "ovirt/ovirt"
-      version = "0.3.0"
     }
   }
 

--- a/examples/resources/ovirt_vm/resource.tf
+++ b/examples/resources/ovirt_vm/resource.tf
@@ -1,5 +1,5 @@
 resource "ovirt_vm" "test" {
-  name        = "hello_world"
+  name        = random_string.vm_name.result
   comment     = "Hello world!"
   cluster_id  = var.cluster_id
   template_id = "00000000-0000-0000-0000-000000000000"

--- a/examples/resources/ovirt_vm/variables.tf
+++ b/examples/resources/ovirt_vm/variables.tf
@@ -36,3 +36,7 @@ variable "mock" {
   type    = bool
   default = true
 }
+resource "random_string" "vm_name" {
+  length  = 16
+  special = false
+}

--- a/examples/resources/ovirt_vm_graphics_consoles/provider.tf
+++ b/examples/resources/ovirt_vm_graphics_consoles/provider.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     ovirt = {
       source  = "ovirt/ovirt"
-      version = "0.3.0"
     }
   }
 

--- a/examples/resources/ovirt_vm_optimize_cpu_settings/provider.tf
+++ b/examples/resources/ovirt_vm_optimize_cpu_settings/provider.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     ovirt = {
       source  = "ovirt/ovirt"
-      version = "0.3.0"
     }
   }
 

--- a/examples/resources/ovirt_vm_start/provider.tf
+++ b/examples/resources/ovirt_vm_start/provider.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     ovirt = {
       source  = "ovirt/ovirt"
-      version = "0.3.0"
     }
   }
 

--- a/examples/resources/ovirt_vm_start/resource.tf
+++ b/examples/resources/ovirt_vm_start/resource.tf
@@ -1,7 +1,21 @@
+resource "ovirt_disk" "test" {
+  storagedomain_id = var.storagedomain_id
+  format           = "raw"
+  size             = 1048576
+  alias            = "test"
+  sparse           = true
+}
+
 resource "ovirt_vm" "test" {
-  name        = "hello_world"
+  name        = random_string.vm_name.result
   cluster_id  = var.cluster_id
   template_id = "00000000-0000-0000-0000-000000000000"
+}
+
+resource "ovirt_disk_attachment" "test" {
+  vm_id          = ovirt_vm.test.id
+  disk_id        = ovirt_disk.test.id
+  disk_interface = "virtio_scsi"
 }
 
 resource "ovirt_nic" "test" {
@@ -12,7 +26,11 @@ resource "ovirt_nic" "test" {
 
 resource "ovirt_vm_start" "test" {
   vm_id = ovirt_vm.test.id
+  // How to stop the VM. Defaults to "shutdown" for an ACPI shutdown.
+  stop_behavior = "stop"
+  // Force-stop the VM even if a backup is currently running.
+  force_stop = true
 
-  # Wait with the start until the NIC is attached.
-  depends_on = [ovirt_nic.test]
+  # Wait with the start until the NIC and disks are attached.
+  depends_on = [ovirt_nic.test, ovirt_disk_attachment.test]
 }

--- a/examples/resources/ovirt_vm_start/variables.tf
+++ b/examples/resources/ovirt_vm_start/variables.tf
@@ -1,3 +1,8 @@
+variable "storagedomain_id" {
+  type        = string
+  description = "ID of the storage domain to create the disk on."
+}
+
 variable "cluster_id" {
   type = string
 }
@@ -38,4 +43,9 @@ variable "tls_system" {
 variable "mock" {
   type    = bool
   default = true
+}
+
+resource "random_string" "vm_name" {
+  length  = 16
+  special = false
 }

--- a/examples/resources/ovirt_vm_tag/provider.tf
+++ b/examples/resources/ovirt_vm_tag/provider.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     ovirt = {
       source  = "ovirt/ovirt"
-      version = "0.3.0"
     }
   }
 

--- a/examples/resources/ovirt_vm_tag/resource.tf
+++ b/examples/resources/ovirt_vm_tag/resource.tf
@@ -1,9 +1,9 @@
 resource "ovirt_tag" "test" {
-  name        = "hello_world"
+  name = random_string.tag_name.result
 }
 
 resource "ovirt_vm" "test" {
-  name        = "hello_world"
+  name        = random_string.vm_name.result
   comment     = "Hello world!"
   cluster_id  = var.cluster_id
   template_id = "00000000-0000-0000-0000-000000000000"
@@ -11,5 +11,5 @@ resource "ovirt_vm" "test" {
 
 resource "ovirt_vm_tag" "test" {
   tag_id = ovirt_tag.test.id
-  vm_id = ovirt_vm.test.id
+  vm_id  = ovirt_vm.test.id
 }

--- a/examples/resources/ovirt_vm_tag/variables.tf
+++ b/examples/resources/ovirt_vm_tag/variables.tf
@@ -40,3 +40,11 @@ variable "mock" {
   type    = bool
   default = true
 }
+resource "random_string" "vm_name" {
+  length  = 16
+  special = false
+}
+resource "random_string" "tag_name" {
+  length  = 16
+  special = false
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-plugin v1.4.4 // indirect
+	github.com/hashicorp/go-version v1.4.0 // indirect
 	github.com/hashicorp/terraform-plugin-docs v0.8.1
 	github.com/hashicorp/terraform-plugin-log v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ func main() {
 	flag.Parse()
 
 	opts := &plugin.ServeOpts{
+		ProviderAddr: "registry.terraform.io/oVirt/ovirt",
 		ProviderFunc: ovirt.New(),
 	}
 

--- a/ovirt/provider.go
+++ b/ovirt/provider.go
@@ -138,7 +138,7 @@ func (p *provider) getProviderFactories() map[string]func() (*schema.Provider, e
 	}
 }
 
-func (p *provider) configureProvider(_ context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
+func (p *provider) configureProvider(ctx context.Context, data *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
 	if mock, ok := data.GetOk("mock"); ok && mock == true {
@@ -213,7 +213,9 @@ func (p *provider) configureProvider(_ context.Context, data *schema.ResourceDat
 		username,
 		password,
 		tls,
-		&terraformLogger{},
+		&terraformLogger{
+			ctx: ctx,
+		},
 		nil,
 	)
 	if err != nil {

--- a/ovirt/resource_ovirt_vm_graphics_consoles.go
+++ b/ovirt/resource_ovirt_vm_graphics_consoles.go
@@ -102,20 +102,20 @@ func (p *provider) vmGraphicsConsolesToData(
 	data *schema.ResourceData,
 	diags diag.Diagnostics,
 ) diag.Diagnostics {
-    cons, err := client.ListVMGraphicsConsoles(ovirtclient.VMID(vmID))
-    if err != nil {
-        return errorToDiags(fmt.Sprintf("list graphics consoles for VM %s", vmID), err)
-    }
-    result := make([]map[string]interface{}, len(cons))
-    for i, con := range cons {
-        result[i] = map[string]interface{}{
-            "id": con.ID(),
-        }
-    }
-    if err := data.Set("console", result); err != nil {
-        diags = append(diags, errorToDiag("setting console on result", err))
-    }
-    return diags
+	cons, err := client.ListVMGraphicsConsoles(ovirtclient.VMID(vmID))
+	if err != nil {
+		return errorToDiags(fmt.Sprintf("list graphics consoles for VM %s", vmID), err)
+	}
+	result := make([]map[string]interface{}, len(cons))
+	for i, con := range cons {
+		result[i] = map[string]interface{}{
+			"id": con.ID(),
+		}
+	}
+	if err := data.Set("console", result); err != nil {
+		diags = append(diags, errorToDiag("setting console on result", err))
+	}
+	return diags
 }
 
 func (p *provider) vmGraphicsConsolesDelete(


### PR DESCRIPTION
## Please describe the change you are making

This PR adds a test runner that iterates over all example directories and runs them against the oVirt Terraform provider if the `OVIRT_URL`, `OVIRT_USERNAME`, and `OVIRT_PASSWORD` environment variables are set.

Some of these don't pass right now, these need to be investigated.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
