### PR TITLE
Fixed TF state management and context bugs

### DIFF
--- a/ovirt/resource_ovirt_disk_attachment.go
+++ b/ovirt/resource_ovirt_disk_attachment.go
@@ -92,9 +92,12 @@ func (p *provider) diskAttachmentRead(ctx context.Context, data *schema.Resource
 		ovirtclient.VMID(vmID),
 		ovirtclient.DiskAttachmentID(data.Id()),
 	)
-	if isNotFound(err) {
-		data.SetId("")
-		return nil
+	if err != nil {
+		if isNotFound(err) {
+			data.SetId("")
+			return nil
+		}
+		return errorToDiags("read disk attachment", err)
 	}
 	return diskAttachmentResourceUpdate(attachment, data)
 }

--- a/ovirt/resource_ovirt_tag.go
+++ b/ovirt/resource_ovirt_tag.go
@@ -66,6 +66,10 @@ func (p *provider) tagRead(ctx context.Context, data *schema.ResourceData, i int
 	client := p.client.WithContext(ctx)
 	tag, err := client.GetTag(ovirtclient.TagID(data.Id()))
 	if err != nil {
+		if isNotFound(err) {
+			data.SetId("")
+			return nil
+		}
 		return errorToDiags(fmt.Sprintf("get tag %s", data.Id()), err)
 	}
 	diags := diag.Diagnostics{}

--- a/ovirt/resource_ovirt_vm_start.go
+++ b/ovirt/resource_ovirt_vm_start.go
@@ -98,7 +98,7 @@ func (p *provider) vmStartCreate(
 ) diag.Diagnostics {
 	client := p.client.WithContext(ctx)
 	id := data.Get("vm_id").(string)
-	if err := p.client.StartVM(ovirtclient.VMID(id)); err != nil {
+	if err := client.StartVM(ovirtclient.VMID(id)); err != nil {
 		return errorToDiags("start VM", err)
 	}
 	desiredStatus := data.Get("status").(string)
@@ -169,7 +169,8 @@ func (p *provider) vmStartImport(ctx context.Context, data *schema.ResourceData,
 	[]*schema.ResourceData,
 	error,
 ) {
-	vm, err := p.client.GetVM(ovirtclient.VMID(data.Id()))
+	client := p.client.WithContext(ctx)
+	vm, err := client.GetVM(ovirtclient.VMID(data.Id()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to import VM %s (%w)", data.Id(), err)
 	}


### PR DESCRIPTION
## Please describe the change you are making

Fixing two bugs across multiple resources:

1. The `p.client` was used without the `WithContext` call in multiple places.
2. When an `ENotFound` error was encountered, the data ID was not set to empty, instead, an error was returned.

This PR supersedes #355.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
