### PR TITLE
Fixes #363: Add os_type parameter to ovirt_vm

### DIFF
--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -36,6 +36,7 @@ resource "ovirt_vm" "test" {
 - `cpu_cores` (Number) Number of CPU cores to allocate to the VM. If set, cpu_threads and cpu_sockets must also be specified.
 - `cpu_sockets` (Number) Number of CPU sockets to allocate to the VM. If set, cpu_cores and cpu_threads must also be specified.
 - `cpu_threads` (Number) Number of CPU threads to allocate to the VM. If set, cpu_cores and cpu_sockets must also be specified.
+- `os_type` (String) Operating system type.
 
 ### Read-Only
 


### PR DESCRIPTION
## Please describe the change you are making

This PR adds the `os_type` parameter to the `ovirt_vm` resource.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
