### PR TITLE
rename storage_domain_id

### DIFF
--- a/docs/resources/disk.md
+++ b/docs/resources/disk.md
@@ -14,7 +14,7 @@ The ovirt_disk resource creates disks in oVirt.
 
 ```terraform
 resource "ovirt_disk" "test" {
-  storagedomain_id = var.storagedomain_id
+  storage_domain_id = var.storage_domain_id
   format           = "raw"
   size             = 1048576
   alias            = "test"

--- a/docs/resources/disk_attachment.md
+++ b/docs/resources/disk_attachment.md
@@ -20,7 +20,7 @@ data "ovirt_blank_template" "blank" {
 }
 
 resource "ovirt_disk" "test" {
-  storagedomain_id = var.storagedomain_id
+  storage_domain_id = var.storage_domain_id
   format           = "raw"
   size             = 1048576
   alias            = "test"

--- a/docs/resources/disk_attachments.md
+++ b/docs/resources/disk_attachments.md
@@ -20,7 +20,7 @@ data "ovirt_blank_template" "blank" {
 }
 
 resource "ovirt_disk" "test" {
-  storagedomain_id = var.storagedomain_id
+  storage_domain_id = var.storage_domain_id
   format           = "raw"
   size             = 1048576
   alias            = "test"

--- a/docs/resources/disk_from_image.md
+++ b/docs/resources/disk_from_image.md
@@ -14,7 +14,7 @@ The ovirt_disk_from_image resource creates disks in oVirt from a local image fil
 
 ```terraform
 resource "ovirt_disk_from_image" "test" {
-  storagedomain_id = var.storagedomain_id
+  storage_domain_id = var.storage_domain_id
   format           = "raw"
   alias            = "test"
   sparse           = true

--- a/docs/resources/vm_start.md
+++ b/docs/resources/vm_start.md
@@ -17,7 +17,7 @@ data "ovirt_blank_template" "blank" {
 }
 
 resource "ovirt_disk_from_image" "test" {
-  storagedomain_id = var.storagedomain_id
+  storage_domain_id = var.storage_domain_id
   format           = "raw"
   alias            = "test"
   sparse           = true

--- a/examples/data-sources/ovirt_disk_attachments/resource.tf
+++ b/examples/data-sources/ovirt_disk_attachments/resource.tf
@@ -2,7 +2,7 @@ data "ovirt_blank_template" "blank" {
 }
 
 resource "ovirt_disk" "test1" {
-  storagedomain_id = var.storagedomain_id
+  storage_domain_id = var.storage_domain_id
   format           = "raw"
   size             = 1048576
   alias            = "test"
@@ -10,7 +10,7 @@ resource "ovirt_disk" "test1" {
 }
 
 resource "ovirt_disk" "test2" {
-  storagedomain_id = var.storagedomain_id
+  storage_domain_id = var.storage_domain_id
   format           = "raw"
   size             = 1048576
   alias            = "test"

--- a/examples/data-sources/ovirt_disk_attachments/variables.tf
+++ b/examples/data-sources/ovirt_disk_attachments/variables.tf
@@ -1,4 +1,4 @@
-variable "storagedomain_id" {
+variable "storage_domain_id" {
   type        = string
   description = "ID of the storage domain to create the disk on."
 }

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -195,7 +195,7 @@ type tfvars struct {
 	Username        string                      `json:"username"`
 	Password        string                      `json:"password"`
 	URL             string                      `json:"url"`
-	StorageDomainID ovirtclient.StorageDomainID `json:"storagedomain_id"`
+	StorageDomainID ovirtclient.StorageDomainID `json:"storage_domain_id"`
 	ClusterID       ovirtclient.ClusterID       `json:"cluster_id"`
 	VNICProfileID   ovirtclient.VNICProfileID   `json:"vnic_profile_id"`
 	TLSInsecure     bool                        `json:"tls_insecure"`

--- a/examples/resources/ovirt_affinity_group/variables.tf
+++ b/examples/resources/ovirt_affinity_group/variables.tf
@@ -2,7 +2,7 @@ variable "cluster_id" {
   type = string
 }
 
-variable "storagedomain_id" {
+variable "storage_domain_id" {
   type        = string
   description = "ID of the storage domain to create the disk on."
 }

--- a/examples/resources/ovirt_disk/resource.tf
+++ b/examples/resources/ovirt_disk/resource.tf
@@ -1,5 +1,5 @@
 resource "ovirt_disk" "test" {
-  storagedomain_id = var.storagedomain_id
+  storage_domain_id = var.storage_domain_id
   format           = "raw"
   size             = 1048576
   alias            = "test"

--- a/examples/resources/ovirt_disk/variables.tf
+++ b/examples/resources/ovirt_disk/variables.tf
@@ -1,4 +1,4 @@
-variable "storagedomain_id" {
+variable "storage_domain_id" {
   type        = string
   description = "ID of the storage domain to create the disk on."
 }

--- a/examples/resources/ovirt_disk_attachment/resource.tf
+++ b/examples/resources/ovirt_disk_attachment/resource.tf
@@ -2,7 +2,7 @@ data "ovirt_blank_template" "blank" {
 }
 
 resource "ovirt_disk" "test" {
-  storagedomain_id = var.storagedomain_id
+  storage_domain_id = var.storage_domain_id
   format           = "raw"
   size             = 1048576
   alias            = "test"

--- a/examples/resources/ovirt_disk_attachment/variables.tf
+++ b/examples/resources/ovirt_disk_attachment/variables.tf
@@ -1,4 +1,4 @@
-variable "storagedomain_id" {
+variable "storage_domain_id" {
   type        = string
   description = "ID of the storage domain to create the disk on."
 }

--- a/examples/resources/ovirt_disk_attachments/resource.tf
+++ b/examples/resources/ovirt_disk_attachments/resource.tf
@@ -2,7 +2,7 @@ data "ovirt_blank_template" "blank" {
 }
 
 resource "ovirt_disk" "test" {
-  storagedomain_id = var.storagedomain_id
+  storage_domain_id = var.storage_domain_id
   format           = "raw"
   size             = 1048576
   alias            = "test"

--- a/examples/resources/ovirt_disk_attachments/variables.tf
+++ b/examples/resources/ovirt_disk_attachments/variables.tf
@@ -1,4 +1,4 @@
-variable "storagedomain_id" {
+variable "storage_domain_id" {
   type        = string
   description = "ID of the storage domain to create the disk on."
 }

--- a/examples/resources/ovirt_disk_from_image/resource.tf
+++ b/examples/resources/ovirt_disk_from_image/resource.tf
@@ -1,5 +1,5 @@
 resource "ovirt_disk_from_image" "test" {
-  storagedomain_id = var.storagedomain_id
+  storage_domain_id = var.storage_domain_id
   format           = "raw"
   alias            = "test"
   sparse           = true

--- a/examples/resources/ovirt_disk_from_image/variables.tf
+++ b/examples/resources/ovirt_disk_from_image/variables.tf
@@ -1,4 +1,4 @@
-variable "storagedomain_id" {
+variable "storage_domain_id" {
   type        = string
   description = "ID of the storage domain to create the disk on."
 }

--- a/examples/resources/ovirt_vm_start/resource.tf
+++ b/examples/resources/ovirt_vm_start/resource.tf
@@ -2,7 +2,7 @@ data "ovirt_blank_template" "blank" {
 }
 
 resource "ovirt_disk_from_image" "test" {
-  storagedomain_id = var.storagedomain_id
+  storage_domain_id = var.storage_domain_id
   format           = "raw"
   alias            = "test"
   sparse           = true

--- a/examples/resources/ovirt_vm_start/variables.tf
+++ b/examples/resources/ovirt_vm_start/variables.tf
@@ -1,4 +1,4 @@
-variable "storagedomain_id" {
+variable "storage_domain_id" {
   type        = string
   description = "ID of the storage domain to create the disk on."
 }


### PR DESCRIPTION
## Please describe the change you are making

This PR renames the `storagedomain_id` to `storage_domain_id` so that the naming is aligned with openshift installer, e.g. [here](https://github.com/openshift/installer/blob/master/data/data/ovirt/variables-ovirt.tf#L46-L53). 

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

yes
