### PR TITLE
Removing rework warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This is a Terraform provider for [oVirt](https://ovirt.org).
 
-<p><center>⚠️ This provider is under reconstruction. See our <a href="https://blogs.ovirt.org/2021/10/important-changes-to-the-ovirt-terraform-provider/">blog post</a>.</center></p>
-
 ## Using this provider
 
 This provider can be used with Terraform 0.13+ from the Terraform registry:


### PR DESCRIPTION
## Please describe the change you are making

 Removing the warning that the provider is being reworked. It is now available in the [Terraform registry](https://registry.terraform.io/providers/oVirt/ovirt/latest/docs).

## Are you the owner of the code you are sending in, or do you have permission of the owner?

Yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

Yes
