### PR TITLE
added null check for sparse and format

### DIFF
--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -72,7 +72,7 @@ Required:
 Optional:
 
 - `format` (String) Disk format for the override. Can be 'raw' or 'cow'.
-- `sparse` (Boolean) Sparse-provision the disk.
+- `provisioning` (String) Provisioning the disk. Must be one of sparse,non-sparse
 
 ## Import
 

--- a/internal/ovirt/resource_ovirt_vm_test.go
+++ b/internal/ovirt/resource_ovirt_vm_test.go
@@ -683,99 +683,133 @@ func TestVMOverrideDisk(t *testing.T) {
 	clusterID := testHelper.GetClusterID()
 	templateID := testHelper.GetBlankTemplateID()
 	storageDomainID := testHelper.GetStorageDomainID()
-	config := fmt.Sprintf(
+
+	baseConfig := fmt.Sprintf(
 		`
-provider "ovirt" {
-	mock = true
-}
-
-resource "ovirt_vm" "source" {
-	cluster_id  = "%s"
-	template_id = "%s"
-	name        = "%s"
-}
-
-resource "ovirt_disk" "source" {
-	storage_domain_id = "%s"
-	format           = "cow"
-    size             = 1048576
-    alias            = "test"
-    sparse           = false
-}
-
-resource "ovirt_disk_attachment" "source" {
-	vm_id          = ovirt_vm.source.id
-	disk_id        = ovirt_disk.source.id
-	disk_interface = "virtio_scsi"
-}
-
-resource "ovirt_template" "source" {
-	vm_id = ovirt_disk_attachment.source.vm_id
-    name  = "%s"
-}
-
-data "ovirt_template_disk_attachments" "source" {
-	template_id = ovirt_template.source.id
-}
-
-resource "ovirt_vm" "one" {
-	template_id = ovirt_template.source.id
-	cluster_id  = "%s"
-	name        = "%s"
-
-	dynamic "template_disk_attachment_override" {
-		for_each = data.ovirt_template_disk_attachments.source.disk_attachments
-		content {
-			disk_id = template_disk_attachment_override.value["disk_id"]
-			format  = "raw"
-            sparse  = true
+		provider "ovirt" {
+			mock = true
 		}
-	}
-}
-`,
+
+		resource "ovirt_vm" "source" {
+			cluster_id  = "%s"
+			template_id = "%s"
+			name        = "%s"
+		}
+
+		resource "ovirt_disk" "source" {
+			storage_domain_id = "%s"
+			format           = "cow"
+			size             = 1048576
+			alias            = "test"
+			sparse           = false
+		}
+
+		resource "ovirt_disk_attachment" "source" {
+			vm_id          = ovirt_vm.source.id
+			disk_id        = ovirt_disk.source.id
+			disk_interface = "virtio_scsi"
+		}
+
+		resource "ovirt_template" "source" {
+			vm_id = ovirt_disk_attachment.source.vm_id
+			name  = "%s"
+		}
+
+		data "ovirt_template_disk_attachments" "source" {
+			template_id = ovirt_template.source.id
+		}`,
 		clusterID,
 		templateID,
 		p.getTestHelper().GenerateTestResourceName(t),
 		storageDomainID,
 		p.getTestHelper().GenerateTestResourceName(t),
-		clusterID,
-		p.getTestHelper().GenerateTestResourceName(t),
 	)
 
-	resource.UnitTest(
-		t, resource.TestCase{
-			ProviderFactories: p.getProviderFactories(),
-			Steps: []resource.TestStep{
-				{
-					Config: config,
-					Check: func(state *terraform.State) error {
-						client := testHelper.GetClient()
-						vmID := state.RootModule().Resources["ovirt_vm.one"].Primary.ID
-						diskAttachments, err := client.ListDiskAttachments(ovirtclient.VMID(vmID))
-						if err != nil {
-							return err
-						}
-						diskAttachment := diskAttachments[0]
-						disk, err := diskAttachment.Disk()
-						if err != nil {
-							return err
-						}
-						if disk.Format() != ovirtclient.ImageFormatRaw {
-							return fmt.Errorf("incorrect disk format: %s", disk.Format())
-						}
-						if !disk.Sparse() {
-							return fmt.Errorf("disk incorrectly created as sparse")
-						}
-						return nil
+	rconf :=
+		`
+		resource "ovirt_vm" "one" {
+			template_id = ovirt_template.source.id
+			cluster_id  = "%s"
+			name        = "%s"
+
+			dynamic "template_disk_attachment_override" {
+				for_each = data.ovirt_template_disk_attachments.source.disk_attachments
+				content {
+					disk_id       = template_disk_attachment_override.value["disk_id"]
+					format        = %s
+					provisioning  = %s
+				}
+			}
+		}`
+
+	testcases := []struct {
+		name              string
+		inputFormat       string
+		inputProvisioning string
+		expectedFormat    ovirtclient.ImageFormat
+		expectedSparse    bool
+	}{
+		{
+			name:              "override sparse",
+			inputFormat:       "null",
+			inputProvisioning: "\"sparse\"",
+			expectedFormat:    ovirtclient.ImageFormatCow,
+			expectedSparse:    true,
+		},
+		{
+			name:              "override format",
+			inputFormat:       "\"raw\"",
+			inputProvisioning: "null",
+			expectedFormat:    ovirtclient.ImageFormatRaw,
+			expectedSparse:    false,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			config := baseConfig + fmt.Sprintf(rconf,
+				clusterID,
+				p.getTestHelper().GenerateTestResourceName(t),
+				testcase.inputFormat,
+				testcase.inputProvisioning,
+			)
+
+			resource.UnitTest(
+				t, resource.TestCase{
+					ProviderFactories: p.getProviderFactories(),
+					Steps: []resource.TestStep{
+						{
+							Config: config,
+							Check: func(state *terraform.State) error {
+								client := testHelper.GetClient()
+								vmID := state.RootModule().Resources["ovirt_vm.one"].Primary.ID
+								diskAttachments, err := client.ListDiskAttachments(ovirtclient.VMID(vmID))
+								if err != nil {
+									return err
+								}
+								diskAttachment := diskAttachments[0]
+								disk, err := diskAttachment.Disk()
+								if err != nil {
+									return err
+								}
+								if disk.Format() != testcase.expectedFormat {
+									return fmt.Errorf("incorrect disk format: %s", disk.Format())
+								}
+								if disk.Sparse() != testcase.expectedSparse {
+									return fmt.Errorf("disk incorrectly created as sparse")
+								}
+								return nil
+							},
+						},
+						{
+							Config:  config,
+							Destroy: true,
+						},
 					},
 				},
-				{
-					Config:  config,
-					Destroy: true,
-				},
-			},
-		},
-	)
+			)
+		})
+	}
 }
 
 func TestMemory(t *testing.T) {


### PR DESCRIPTION
## Please describe the change you are making

Currently, if `
- ovirt_vm.template_disk_attachment_override.sparse` 
- and/or `ovirt_vm.template_disk_attachment_override.format` 
are not passed or set to null, the terraform state omits those fields. However, the values of those fields are set later on when retrieving them via `data.Get` to the default value of the respective type (e.g. false for bool). 

This PR tries to tackle this issue by introducing "invalid" default values that indicate that those fields have not been set. 

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

yes
