### PR TITLE
fix: memory_ballooning for false value properly set

### DIFF
--- a/internal/ovirt/resource_ovirt_disk.go
+++ b/internal/ovirt/resource_ovirt_disk.go
@@ -109,7 +109,10 @@ func (p *provider) diskCreate(
 			}
 		}
 	}
-	if sparse, ok := data.GetOk("sparse"); ok {
+	// GetOkExists is necessary here due to GetOk check for default values (for sparse=false, ok would be false, too)
+	// see: https://github.com/hashicorp/terraform/pull/15723
+	//nolint:staticcheck
+	if sparse, ok := data.GetOkExists("sparse"); ok {
 		params, err = params.WithSparse(sparse.(bool))
 		if err != nil {
 			return diag.Diagnostics{

--- a/internal/ovirt/resource_ovirt_vm.go
+++ b/internal/ovirt/resource_ovirt_vm.go
@@ -326,7 +326,10 @@ func handleVMSerialConsole(
 	params ovirtclient.BuildableVMParameters,
 	diags diag.Diagnostics,
 ) diag.Diagnostics {
-	serialConsole, ok := data.GetOk("serial_console")
+	// GetOkExists is necessary here due to GetOk check for default values (for serial_console=false, ok would be false, too)
+	// see: https://github.com/hashicorp/terraform/pull/15723
+	//nolint:staticcheck
+	serialConsole, ok := data.GetOkExists("serial_console")
 	if !ok {
 		return diags
 	}
@@ -340,7 +343,10 @@ func handleVMClone(
 	params ovirtclient.BuildableVMParameters,
 	diags diag.Diagnostics,
 ) diag.Diagnostics {
-	shouldClone, ok := data.GetOk("clone")
+	// GetOkExists is necessary here due to GetOk check for default values (for clone=false, ok would be false, too)
+	// see: https://github.com/hashicorp/terraform/pull/15723
+	//nolint:staticcheck
+	shouldClone, ok := data.GetOkExists("clone")
 	if !ok {
 		return diags
 	}
@@ -414,7 +420,10 @@ func handleVMMemoryPolicy(
 			addMemoryPolicy = true
 		}
 	}
-	ballooning, ok := data.GetOk("memory_ballooning")
+	// GetOkExists is necessary here due to GetOk check for default values (for ballooning=false, ok would be false, too)
+	// see: https://github.com/hashicorp/terraform/pull/15723
+	//nolint:staticcheck
+	ballooning, ok := data.GetOkExists("memory_ballooning")
 	if ok {
 		var err error
 		_, err = memoryPolicy.WithBallooning(ballooning.(bool))


### PR DESCRIPTION
## Please describe the change you are making

Currently, if the `memory_ballooning` flag is set to `false`, the default-value check of `GetOk` of the terraform sdk returns the status not found - therefore skipping setting the value. This results in the engine setting the value to the default one (true). This PR attempts to fix this by using the `GetOkExists` function - which should be used carefully. 

https://github.com/hashicorp/terraform/pull/15723
https://github.com/hashicorp/terraform-plugin-sdk/pull/350

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes

## The code will be published under the BSD 3 clause license. Have you read and understood this license?

yes
