### PR TITLE
Add storage_domain_id to template_disk_attachment_override

### DIFF
--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -74,6 +74,7 @@ Optional:
 
 - `format` (String) Disk format for the override. Can be 'raw' or 'cow'.
 - `provisioning` (String) Provisioning the disk. Must be one of sparse,non-sparse
+- `storage_domain_id` (String) ID of the storage domain where the new disk will be placed.
 
 ## Import
 

--- a/internal/ovirt/resource_ovirt_vm.go
+++ b/internal/ovirt/resource_ovirt_vm.go
@@ -148,6 +148,13 @@ var vmSchema = map[string]*schema.Schema{
 					Description:      fmt.Sprintf("Provisioning the disk. Must be one of %s", strings.Join(provisioningValues(), ",")),
 					ValidateDiagFunc: validateEnum(provisioningValues()),
 				},
+				"storage_domain_id": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ForceNew:         true,
+					Description:      "ID of the storage domain where the new disk will be placed.",
+					ValidateDiagFunc: validateUUID,
+				},
 			},
 		},
 	},
@@ -414,6 +421,14 @@ func handleTemplateDiskAttachmentOverride(
 			disk, err = disk.WithSparse(isSparse)
 			if err != nil {
 				diags = append(diags, errorToDiag("set sparse on disk", err))
+				return diags
+			}
+		}
+		if storageDomainID, ok := entry["storage_domain_id"]; ok && storageDomainID != "" {
+			storageDomainObj := ovirtclient.StorageDomainID(storageDomainID.(string))
+			disk, err = disk.WithStorageDomainID(storageDomainObj)
+			if err != nil {
+				diags = append(diags, errorToDiag("set storage domain id", err))
 				return diags
 			}
 		}


### PR DESCRIPTION
## Please describe the change you are making
This way it is possible to deploy a VM directly on another storage domain from Terraform.

Also note that "clone = true" was added, otherwise it's not possible to put a new VM on another datastore.
...

## Are you the owner of the code you are sending in, or do you have permission of the owner?
Yes
...

## The code will be published under the BSD 3 clause license. Have you read and understood this license?
Yes
...
