### PR TITLE
ci: update .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,7 @@
-before:
-  hooks:
-    - go mod tidy
+version: 2
 builds:
-  - env:
+  - id: build
+    env:
       - CGO_ENABLED=0
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
@@ -25,8 +24,11 @@ builds:
       - goos: windows
         goarch: arm64
     binary: "{{ .ProjectName }}_{{ .Version }}"
+    hooks:
+      pre:
+        - go mod tidy
 archives:
-  - format: zip
+  - formats: ["zip"]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
@@ -45,4 +47,4 @@ signs:
     output: false
 release:
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
Update the .goreleaser.yml file to make it compatible with latest GoReleaser version (v2).